### PR TITLE
feat(sdk): add experiment group analytics client

### DIFF
--- a/tests/unit/cloud/test_backend_client.py
+++ b/tests/unit/cloud/test_backend_client.py
@@ -208,6 +208,178 @@ class TestBackendIntegratedClient:
         assert reader._auth_headers() == {"Authorization": "Bearer stored.header.sig"}
 
     @pytest.mark.asyncio
+    async def test_experiment_groups_facade_uses_read_client(self, backend_client):
+        """Experiment-group namespace is read-only and delegates to the read client."""
+        sentinel = object()
+
+        class FakeReadClient:
+            def __init__(self):
+                self.calls = []
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                return None
+
+            async def list_experiment_groups(self, *args, **kwargs):
+                self.calls.append(("list", args, kwargs))
+                return sentinel
+
+            async def get_experiment_group(self, *args, **kwargs):
+                self.calls.append(("get", args, kwargs))
+                return sentinel
+
+            async def list_experiment_group_configuration_runs(self, *args, **kwargs):
+                self.calls.append(("configuration_runs", args, kwargs))
+                return sentinel
+
+        fake_reader = FakeReadClient()
+
+        with (
+            patch(
+                "traigent.cloud.analytics_auth.resolve_analytics_read_client_credentials",
+                new=AsyncMock(return_value={"api_key": "uk_read"}),
+            ),
+            patch(
+                "traigent.cloud.analytics_client.BackendAnalyticsClient",
+                return_value=fake_reader,
+            ),
+        ):
+            list_result = await backend_client.experiment_groups.list(
+                "proj_abc",
+                agent_id="agent_1",
+                dataset_id="dataset_1",
+                page=2,
+                page_size=25,
+            )
+            get_result = await backend_client.experiment_groups.get("grp_1", "proj_abc")
+            configuration_runs_result = (
+                await backend_client.experiment_groups.configuration_runs(
+                    "grp_1", "proj_abc", page=3, page_size=10
+                )
+            )
+            with pytest.raises(ValueError, match="project_id"):
+                await backend_client.experiment_groups.list("  ")
+            with pytest.raises(TypeError):
+                await backend_client.experiment_groups.list()
+            with pytest.raises(TypeError):
+                await backend_client.experiment_groups.get("grp_1")
+            with pytest.raises(TypeError):
+                await backend_client.experiment_groups.configuration_runs("grp_1")
+
+        assert list_result is sentinel
+        assert get_result is sentinel
+        assert configuration_runs_result is sentinel
+        assert fake_reader.calls == [
+            (
+                "list",
+                ("proj_abc",),
+                {
+                    "agent_id": "agent_1",
+                    "dataset_id": "dataset_1",
+                    "page": 2,
+                    "page_size": 25,
+                },
+            ),
+            ("get", ("grp_1", "proj_abc"), {}),
+            (
+                "configuration_runs",
+                ("grp_1", "proj_abc"),
+                {"page": 3, "page_size": 10},
+            ),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_analytics_experiment_groups_alias_forwards_filters(
+        self, backend_client
+    ):
+        """Analytics compatibility alias forwards documented group filters."""
+        sentinel = object()
+
+        class FakeReadClient:
+            def __init__(self):
+                self.calls = []
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                return None
+
+            async def list_experiment_groups(self, *args, **kwargs):
+                self.calls.append(("list", args, kwargs))
+                return sentinel
+
+            async def get_experiment_group(self, *args, **kwargs):
+                self.calls.append(("get", args, kwargs))
+                return sentinel
+
+            async def list_experiment_group_configuration_runs(self, *args, **kwargs):
+                self.calls.append(("configuration_runs", args, kwargs))
+                return sentinel
+
+        fake_reader = FakeReadClient()
+
+        with (
+            patch(
+                "traigent.cloud.analytics_auth.resolve_analytics_read_client_credentials",
+                new=AsyncMock(return_value={"api_key": "uk_read"}),
+            ),
+            patch(
+                "traigent.cloud.analytics_client.BackendAnalyticsClient",
+                return_value=fake_reader,
+            ),
+        ):
+            list_result = await backend_client.analytics.list_experiment_groups(
+                "proj_abc",
+                agent_id="agent_1",
+                dataset_id="dataset_1",
+                page=2,
+                page_size=25,
+            )
+            get_result = await backend_client.analytics.get_experiment_group(
+                "grp_1", "proj_abc"
+            )
+            configuration_runs_result = (
+                await backend_client.analytics.list_experiment_group_configuration_runs(
+                    "grp_1", "proj_abc", page=3, page_size=10
+                )
+            )
+            with pytest.raises(ValueError, match="project_id"):
+                await backend_client.analytics.list_experiment_groups("  ")
+            with pytest.raises(TypeError):
+                await backend_client.analytics.list_experiment_groups()
+            with pytest.raises(TypeError):
+                await backend_client.analytics.get_experiment_group("grp_1")
+            with pytest.raises(TypeError):
+                await backend_client.analytics.list_experiment_group_configuration_runs(
+                    "grp_1"
+                )
+
+        assert list_result is sentinel
+        assert get_result is sentinel
+        assert configuration_runs_result is sentinel
+        assert fake_reader.calls == [
+            (
+                "list",
+                ("proj_abc",),
+                {
+                    "agent_id": "agent_1",
+                    "dataset_id": "dataset_1",
+                    "page": 2,
+                    "page_size": 25,
+                },
+            ),
+            ("get", ("grp_1", "proj_abc"), {}),
+            (
+                "configuration_runs",
+                ("grp_1", "proj_abc"),
+                {"page": 3, "page_size": 10},
+            ),
+        ]
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         ("facade_method", "reader_method", "kwargs"),
         [

--- a/tests/unit/cloud/test_experiment_groups_client.py
+++ b/tests/unit/cloud/test_experiment_groups_client.py
@@ -1,0 +1,415 @@
+"""Unit tests for experiment-group/cohort read DTOs and client methods."""
+
+from __future__ import annotations
+
+import builtins
+import importlib.util
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+HTTPX_AVAILABLE = importlib.util.find_spec("httpx") is not None
+
+pytestmark = pytest.mark.skipif(not HTTPX_AVAILABLE, reason="httpx not installed")
+
+
+def _make_client():
+    from traigent.cloud.analytics_client import BackendAnalyticsClient
+
+    return BackendAnalyticsClient(
+        backend_url="http://localhost:5000",
+        api_key="uk_test_key",  # pragma: allowlist secret
+    )
+
+
+def _success_envelope(data: object) -> dict[str, object]:
+    return {"success": True, "message": "ok", "data": data}
+
+
+def _mock_get_response(client, data: object):
+    mock_response = MagicMock()
+    mock_response.json.return_value = _success_envelope(data)
+    mock_response.raise_for_status = MagicMock()
+    mock_http = AsyncMock()
+    mock_http.get.return_value = mock_response
+    client._client = mock_http
+    return mock_http, mock_response
+
+
+class TestExperimentGroupDTOs:
+    def test_overview_preserves_nullable_dataset_and_source_ids(self) -> None:
+        from traigent.cloud.dtos import ExperimentGroupOverviewDTO
+
+        dto = ExperimentGroupOverviewDTO.from_dict(
+            {
+                "group_id": "grp_1",
+                "name": "Production prompt cohort",
+                "agent_id": "agent_1",
+                "dataset_id": None,
+                "experiment_count": 1,
+                "experiment_run_count": 1,
+                "configuration_run_count": 2,
+                "first_experiment_created_at": "2026-06-29T10:00:00Z",
+                "last_experiment_updated_at": "2026-06-29T10:30:00Z",
+                "first_experiment_run_created_at": "2026-06-29T10:01:00Z",
+                "last_experiment_run_updated_at": "2026-06-29T10:31:00Z",
+                "status_summary": {
+                    "experiment_run_status_counts": {"completed": 1},
+                    "configuration_run_status_counts": {"completed": 2},
+                },
+                "source_experiments": [
+                    {
+                        "experiment_id": "exp_1",
+                        "experiment_run_id": "run_1",
+                        "name": "first run",
+                    }
+                ],
+                "configuration_runs_count": 2,
+                "backend_added": {"kept": True},
+            }
+        )
+
+        assert dto.dataset_id is None
+        assert dto.agent_id == "agent_1"
+        assert dto.experiment_run_count == 1
+        assert dto.configuration_run_count == 2
+        assert dto.configuration_runs_count == 2
+        assert dto.first_experiment_created_at == "2026-06-29T10:00:00Z"
+        assert dto.last_experiment_run_updated_at == "2026-06-29T10:31:00Z"
+        assert dto.status_summary.experiment_run_status_counts == {"completed": 1}
+        assert dto.status_summary.configuration_run_status_counts == {"completed": 2}
+        assert dto.source_experiments[0].experiment_id == "exp_1"
+        assert dto.source_experiments[0].experiment_run_id == "run_1"
+        assert dto.to_dict()["backend_added"] == {"kept": True}
+        assert dto.to_dict()["configuration_run_count"] == 2
+
+    def test_grouped_configuration_rows_do_not_dedupe_by_config_or_measures(
+        self,
+    ) -> None:
+        from traigent.cloud.dtos import GroupedConfigurationRunsPageDTO
+
+        payload = {
+            "configuration_runs": [
+                {
+                    "configuration_run_id": "cfg_run_a",
+                    "experiment_run_id": "exp_run_1",
+                    "experiment_id": "exp_1",
+                    "configuration": {"temperature": 0.2},
+                    "measures": {"quality": 0.9},
+                    "started_at": "2026-06-29T10:01:00Z",
+                    "completed_at": "2026-06-29T10:02:00Z",
+                },
+                {
+                    "configuration_run_id": "cfg_run_b",
+                    "experiment_run_id": "exp_run_2",
+                    "experiment_id": "exp_2",
+                    "configuration": {"temperature": 0.2},
+                    "measures": {"quality": 0.9},
+                },
+            ],
+            "total": 2,
+        }
+
+        dto = GroupedConfigurationRunsPageDTO.from_dict(payload)
+
+        assert [row.configuration_run_id for row in dto.items] == [
+            "cfg_run_a",
+            "cfg_run_b",
+        ]
+        assert [row.experiment_run_id for row in dto.items] == [
+            "exp_run_1",
+            "exp_run_2",
+        ]
+        assert [row.experiment_id for row in dto.items] == ["exp_1", "exp_2"]
+        assert dto.items[0].started_at == "2026-06-29T10:01:00Z"
+        assert dto.items[0].completed_at == "2026-06-29T10:02:00Z"
+        assert dto.items[0].to_dict()["started_at"] == "2026-06-29T10:01:00Z"
+
+    def test_grouped_configuration_rows_require_source_ids(self) -> None:
+        from traigent.cloud.dtos import GroupedConfigurationRunRowDTO
+
+        with pytest.raises(ValueError, match="experiment_run_id"):
+            GroupedConfigurationRunRowDTO.from_dict(
+                {
+                    "configuration_run_id": "cfg_run_a",
+                    "experiment_id": "exp_1",
+                }
+            )
+
+
+class TestExperimentGroupClient:
+    @pytest.mark.asyncio
+    async def test_list_experiment_groups_calls_endpoint_without_null_dataset_filter(
+        self,
+    ) -> None:
+        client = _make_client()
+        mock_http, mock_response = _mock_get_response(
+            client,
+            {
+                "items": [
+                    {
+                        "group_id": "grp_1",
+                        "name": "Production prompt cohort",
+                        "dataset_id": None,
+                        "source_experiments": [
+                            {
+                                "experiment_id": "exp_1",
+                                "experiment_run_id": "run_1",
+                            }
+                        ],
+                    }
+                ],
+                "page": 2,
+                "page_size": 10,
+                "total": 1,
+                "total_pages": 1,
+            },
+        )
+
+        result = await client.list_experiment_groups(
+            "proj_abc", dataset_id=None, page=2, page_size=10
+        )
+
+        assert result.items[0].dataset_id is None
+        assert result.items[0].source_experiments[0].experiment_id == "exp_1"
+        mock_response.raise_for_status.assert_called_once()
+        mock_http.get.assert_called_once_with(
+            "/api/v1/experiment-groups",
+            headers={"X-Project-Id": "proj_abc"},
+            params={"page": "2", "page_size": "10"},
+        )
+        mock_http.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_list_experiment_groups_sends_agent_and_dataset_filters_when_present(
+        self,
+    ) -> None:
+        client = _make_client()
+        mock_http, _ = _mock_get_response(client, {"experiment_groups": []})
+
+        await client.list_experiment_groups(
+            "proj_abc",
+            agent_id="agent_1",
+            dataset_id="dataset_1",
+        )
+
+        mock_http.get.assert_called_once_with(
+            "/api/v1/experiment-groups",
+            headers={"X-Project-Id": "proj_abc"},
+            params={
+                "agent_id": "agent_1",
+                "dataset_id": "dataset_1",
+                "page": "1",
+                "page_size": "50",
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_experiment_group_url_encodes_id_and_preserves_rows(
+        self,
+    ) -> None:
+        client = _make_client()
+        mock_http, _ = _mock_get_response(
+            client,
+            {
+                "group_id": "group/with slash",
+                "name": "Grouped runs",
+                "grouped_configurations": [
+                    {
+                        "configuration_run_id": "cfg_run_a",
+                        "experiment_run_id": "exp_run_1",
+                        "experiment_id": "exp_1",
+                        "configuration": {"model": "gpt"},
+                    },
+                    {
+                        "configuration_run_id": "cfg_run_b",
+                        "experiment_run_id": "exp_run_1",
+                        "experiment_id": "exp_1",
+                        "configuration": {"model": "gpt"},
+                    },
+                ],
+            },
+        )
+
+        result = await client.get_experiment_group("group/with slash", "proj_abc")
+
+        assert [row.configuration_run_id for row in result.grouped_configurations] == [
+            "cfg_run_a",
+            "cfg_run_b",
+        ]
+        mock_http.get.assert_called_once_with(
+            "/api/v1/experiment-groups/group%2Fwith%20slash",
+            headers={"X-Project-Id": "proj_abc"},
+            params=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_experiment_group_parses_canonical_detail_shape(
+        self,
+    ) -> None:
+        client = _make_client()
+        _mock_get_response(
+            client,
+            {
+                "group": {
+                    "group_id": "grp_1",
+                    "name": "Canonical cohort",
+                    "agent_id": "agent_1",
+                    "dataset_id": None,
+                    "experiment_count": 2,
+                    "experiment_run_count": 3,
+                    "configuration_run_count": 5,
+                    "first_experiment_created_at": "2026-06-29T10:00:00Z",
+                    "last_experiment_updated_at": "2026-06-29T11:00:00Z",
+                    "first_experiment_run_created_at": "2026-06-29T10:05:00Z",
+                    "last_experiment_run_updated_at": "2026-06-29T11:05:00Z",
+                    "status_summary": {
+                        "experiment_run_status_counts": {
+                            "completed": 2,
+                            "failed": 1,
+                        },
+                        "configuration_run_status_counts": {
+                            "completed": 4,
+                            "failed": 1,
+                        },
+                    },
+                },
+                "source_experiments": [
+                    {
+                        "experiment_id": "exp_1",
+                        "experiment_run_id": "run_1",
+                    },
+                    {
+                        "experiment_id": "exp_2",
+                        "experiment_run_id": "run_2",
+                    },
+                ],
+            },
+        )
+
+        result = await client.get_experiment_group("grp_1", "proj_abc")
+
+        assert result.group_id == "grp_1"
+        assert result.agent_id == "agent_1"
+        assert result.dataset_id is None
+        assert result.experiment_count == 2
+        assert result.experiment_run_count == 3
+        assert result.configuration_run_count == 5
+        assert result.first_experiment_created_at == "2026-06-29T10:00:00Z"
+        assert result.last_experiment_run_updated_at == "2026-06-29T11:05:00Z"
+        assert result.status_summary.experiment_run_status_counts == {
+            "completed": 2,
+            "failed": 1,
+        }
+        assert result.status_summary.configuration_run_status_counts == {
+            "completed": 4,
+            "failed": 1,
+        }
+        assert [row.experiment_id for row in result.source_experiments] == [
+            "exp_1",
+            "exp_2",
+        ]
+        assert result.to_dict()["configuration_run_count"] == 5
+
+    @pytest.mark.asyncio
+    async def test_list_group_configuration_runs_calls_endpoint_with_pagination(
+        self,
+    ) -> None:
+        client = _make_client()
+        mock_http, _ = _mock_get_response(
+            client,
+            {
+                "configuration_runs": [
+                    {
+                        "configuration_run_id": "cfg_run_1",
+                        "experiment_run_id": "exp_run_1",
+                        "experiment_id": "exp_1",
+                        "started_at": "2026-06-29T10:01:00Z",
+                        "completed_at": "2026-06-29T10:02:00Z",
+                    }
+                ],
+                "page": 3,
+                "page_size": 25,
+                "total": 1,
+            },
+        )
+
+        result = await client.list_experiment_group_configuration_runs(
+            "grp 1", "proj_abc", page=3, page_size=25
+        )
+
+        assert result.items[0].configuration_run_id == "cfg_run_1"
+        assert result.items[0].experiment_run_id == "exp_run_1"
+        assert result.items[0].experiment_id == "exp_1"
+        assert result.items[0].started_at == "2026-06-29T10:01:00Z"
+        assert result.items[0].completed_at == "2026-06-29T10:02:00Z"
+        mock_http.get.assert_called_once_with(
+            "/api/v1/experiment-groups/grp%201/configuration-runs",
+            headers={"X-Project-Id": "proj_abc"},
+            params={"page": "3", "page_size": "25"},
+        )
+        mock_http.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_experiment_group_reads_require_project_id_before_http(
+        self,
+    ) -> None:
+        client = _make_client()
+        mock_http = AsyncMock()
+        client._client = mock_http
+
+        with pytest.raises(TypeError):
+            await client.list_experiment_groups()
+        with pytest.raises(TypeError):
+            await client.get_experiment_group("grp_1")
+        with pytest.raises(TypeError):
+            await client.list_experiment_group_configuration_runs("grp_1")
+
+        mock_http.get.assert_not_called()
+        mock_http.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("method_name", "args"),
+        [
+            ("list_experiment_groups", ("  ",)),
+            ("get_experiment_group", ("grp_1", "  ")),
+            ("list_experiment_group_configuration_runs", ("grp_1", "  ")),
+        ],
+    )
+    async def test_experiment_group_reads_reject_empty_project_id_before_http(
+        self,
+        method_name: str,
+        args: tuple[str, ...],
+    ) -> None:
+        client = _make_client()
+        mock_http = AsyncMock()
+        client._client = mock_http
+
+        with pytest.raises(ValueError, match="project_id"):
+            await getattr(client, method_name)(*args)
+
+        mock_http.get.assert_not_called()
+        mock_http.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_experiment_group_reads_do_not_import_sync_manager(
+        self,
+    ) -> None:
+        client = _make_client()
+        mock_http, _ = _mock_get_response(client, {"items": []})
+        original_import = builtins.__import__
+
+        def guarded_import(name, *args, **kwargs):
+            if name == "traigent.cloud.sync_manager":
+                raise AssertionError("experiment group reads touched sync_manager")
+            return original_import(name, *args, **kwargs)
+
+        try:
+            builtins.__import__ = guarded_import
+            await client.list_experiment_groups("proj_abc")
+        finally:
+            builtins.__import__ = original_import
+
+        mock_http.get.assert_called_once()
+        mock_http.post.assert_not_called()

--- a/traigent/cloud/__init__.py
+++ b/traigent/cloud/__init__.py
@@ -30,6 +30,34 @@ _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
         "traigent.cloud.dtos",
         "WalletTopUpPacksResponseDTO",
     ),
+    "ExperimentGroupSourceExperimentDTO": (
+        "traigent.cloud.dtos",
+        "ExperimentGroupSourceExperimentDTO",
+    ),
+    "GroupedConfigurationRunRowDTO": (
+        "traigent.cloud.dtos",
+        "GroupedConfigurationRunRowDTO",
+    ),
+    "ExperimentGroupOverviewDTO": (
+        "traigent.cloud.dtos",
+        "ExperimentGroupOverviewDTO",
+    ),
+    "ExperimentGroupDetailDTO": (
+        "traigent.cloud.dtos",
+        "ExperimentGroupDetailDTO",
+    ),
+    "ExperimentGroupStatusSummaryDTO": (
+        "traigent.cloud.dtos",
+        "ExperimentGroupStatusSummaryDTO",
+    ),
+    "ExperimentGroupsPageDTO": (
+        "traigent.cloud.dtos",
+        "ExperimentGroupsPageDTO",
+    ),
+    "GroupedConfigurationRunsPageDTO": (
+        "traigent.cloud.dtos",
+        "GroupedConfigurationRunsPageDTO",
+    ),
     "UsageTracker": ("traigent.cloud.billing", "UsageTracker"),
     "SmartSubsetSelector": ("traigent.cloud.subset_selection", "SmartSubsetSelector"),
     "DiverseSampling": ("traigent.cloud.subset_selection", "DiverseSampling"),
@@ -54,6 +82,13 @@ __all__ = [
     "WalletInsufficientBalanceErrorDTO",
     "WalletTopUpPackDTO",
     "WalletTopUpPacksResponseDTO",
+    "ExperimentGroupSourceExperimentDTO",
+    "GroupedConfigurationRunRowDTO",
+    "ExperimentGroupOverviewDTO",
+    "ExperimentGroupDetailDTO",
+    "ExperimentGroupStatusSummaryDTO",
+    "ExperimentGroupsPageDTO",
+    "GroupedConfigurationRunsPageDTO",
     "UsageTracker",
     "SmartSubsetSelector",
     "DiverseSampling",

--- a/traigent/cloud/analytics_client.py
+++ b/traigent/cloud/analytics_client.py
@@ -29,6 +29,9 @@ Wired analytics endpoints:
 * ``GET /api/v1/analytics/runs/{run_id}/leaderboard``
 * ``GET /api/v1/analytics/runs/{run_id}/parameter-insights``
 * ``GET /api/v1/analytics/runs/{run_id}/example-insights``
+* ``GET /api/v1/experiment-groups``
+* ``GET /api/v1/experiment-groups/{group_id}``
+* ``GET /api/v1/experiment-groups/{group_id}/configuration-runs``
 """
 
 # Traceability: CONC-Layer-Infra CONC-Security FUNC-CLOUD-HYBRID FUNC-ANALYTICS REQ-CLOUD-009
@@ -41,6 +44,11 @@ from collections.abc import Mapping, Sequence
 from typing import Any, cast
 from urllib.parse import quote
 
+from traigent.cloud.dtos import (
+    ExperimentGroupDetailDTO,
+    ExperimentGroupsPageDTO,
+    GroupedConfigurationRunsPageDTO,
+)
 from traigent.cloud.url_security import validate_cloud_base_url
 from traigent.cloud.user_agent import get_sdk_user_agent
 from traigent.utils.logging import get_logger
@@ -752,6 +760,66 @@ class BackendAnalyticsClient:
                 what="redactions",
             ),
         }
+
+    async def list_experiment_groups(
+        self,
+        project_id: str,
+        *,
+        agent_id: str | None = None,
+        dataset_id: str | None = None,
+        page: int = 1,
+        page_size: int = 50,
+    ) -> ExperimentGroupsPageDTO:
+        """Return experiment groups/cohorts visible to the authenticated user."""
+        payload = await self._get_json(
+            "/api/v1/experiment-groups",
+            what="experiment groups",
+            headers=self._project_headers(project_id),
+            params=_without_none(
+                {
+                    "agent_id": str(agent_id) if agent_id is not None else None,
+                    "dataset_id": str(dataset_id) if dataset_id is not None else None,
+                    "page": str(page),
+                    "page_size": str(page_size),
+                }
+            ),
+        )
+        return ExperimentGroupsPageDTO.from_dict(payload)
+
+    async def get_experiment_group(
+        self,
+        group_id: str,
+        project_id: str,
+    ) -> ExperimentGroupDetailDTO:
+        """Return one experiment group/cohort detail payload."""
+        path = f"/api/v1/experiment-groups/{_quote_segment(group_id, field='group_id')}"
+        payload = await self._get_json(
+            path,
+            what="experiment group",
+            headers=self._project_headers(project_id),
+        )
+        return ExperimentGroupDetailDTO.from_dict(payload)
+
+    async def list_experiment_group_configuration_runs(
+        self,
+        group_id: str,
+        project_id: str,
+        *,
+        page: int = 1,
+        page_size: int = 50,
+    ) -> GroupedConfigurationRunsPageDTO:
+        """Return source-preserving configuration rows for one group/cohort."""
+        path = (
+            "/api/v1/experiment-groups/"
+            f"{_quote_segment(group_id, field='group_id')}/configuration-runs"
+        )
+        payload = await self._get_json(
+            path,
+            what="experiment group configuration runs",
+            headers=self._project_headers(project_id),
+            params={"page": str(page), "page_size": str(page_size)},
+        )
+        return GroupedConfigurationRunsPageDTO.from_dict(payload)
 
 
 def _require_non_empty(value: str, *, field: str) -> str:

--- a/traigent/cloud/backend_client.py
+++ b/traigent/cloud/backend_client.py
@@ -165,6 +165,13 @@ STATIC_POLICY_TEXT = (
 )
 
 
+def _require_project_id(project_id: str) -> str:
+    text = (project_id or "").strip()
+    if not text:
+        raise ValueError("project_id must be a non-empty string.")
+    return text
+
+
 class _SyncBackendTransientError(RetryableError):
     """Retryable wrapper for transient sync backend transport failures."""
 
@@ -255,6 +262,7 @@ __all__ = [
     "AnalyticsNamespace",
     "BackendClientConfig",
     "BackendIntegratedClient",
+    "ExperimentGroupsNamespace",
 ]
 
 
@@ -413,6 +421,121 @@ class AnalyticsNamespace:
             return cast(
                 dict[str, Any],
                 await reader.get_example_insights(project_id, run_id),
+            )
+
+    async def list_experiment_groups(
+        self,
+        project_id: str,
+        *,
+        agent_id: str | None = None,
+        dataset_id: str | None = None,
+        page: int = 1,
+        page_size: int = 50,
+    ) -> Any:
+        """Compatibility alias for ``client.experiment_groups.list``."""
+        project_id = _require_project_id(project_id)
+        async with await self._new_read_client() as reader:
+            return await reader.list_experiment_groups(
+                project_id,
+                agent_id=agent_id,
+                dataset_id=dataset_id,
+                page=page,
+                page_size=page_size,
+            )
+
+    async def get_experiment_group(
+        self,
+        group_id: str,
+        project_id: str,
+    ) -> Any:
+        """Compatibility alias for ``client.experiment_groups.get``."""
+        project_id = _require_project_id(project_id)
+        async with await self._new_read_client() as reader:
+            return await reader.get_experiment_group(group_id, project_id)
+
+    async def list_experiment_group_configuration_runs(
+        self,
+        group_id: str,
+        project_id: str,
+        *,
+        page: int = 1,
+        page_size: int = 50,
+    ) -> Any:
+        """Compatibility alias for ``client.experiment_groups.configuration_runs``."""
+        project_id = _require_project_id(project_id)
+        async with await self._new_read_client() as reader:
+            return await reader.list_experiment_group_configuration_runs(
+                group_id,
+                project_id,
+                page=page,
+                page_size=page_size,
+            )
+
+
+class ExperimentGroupsNamespace:
+    """Read-only ``client.experiment_groups`` accessor for group/cohort reads."""
+
+    def __init__(self, client: "BackendIntegratedClient") -> None:
+        self._client = client
+
+    async def _new_read_client(self) -> Any:
+        from traigent.cloud.analytics_auth import (
+            resolve_analytics_read_client_credentials,
+        )
+        from traigent.cloud.analytics_client import BackendAnalyticsClient
+
+        credential_kwargs = await resolve_analytics_read_client_credentials(
+            self._client.auth_manager.auth,
+            api_key_fallback=self._client._api_key_fallback,
+        )
+        return BackendAnalyticsClient(
+            backend_url=self._client.base_url,
+            timeout=self._client.timeout,
+            **credential_kwargs,
+        )
+
+    async def list(
+        self,
+        project_id: str,
+        *,
+        agent_id: str | None = None,
+        dataset_id: str | None = None,
+        page: int = 1,
+        page_size: int = 50,
+    ) -> Any:
+        """List experiment groups/cohorts."""
+        project_id = _require_project_id(project_id)
+        async with await self._new_read_client() as reader:
+            return await reader.list_experiment_groups(
+                project_id,
+                agent_id=agent_id,
+                dataset_id=dataset_id,
+                page=page,
+                page_size=page_size,
+            )
+
+    async def get(self, group_id: str, project_id: str) -> Any:
+        """Read one experiment group/cohort."""
+        project_id = _require_project_id(project_id)
+        async with await self._new_read_client() as reader:
+            return await reader.get_experiment_group(group_id, project_id)
+
+    async def configuration_runs(
+        self,
+        group_id: str,
+        project_id: str,
+        *,
+        page: int = 1,
+        page_size: int = 50,
+    ) -> Any:
+        """List source-preserving configuration rows for a group/cohort."""
+        project_id = _require_project_id(project_id)
+        async with await self._new_read_client() as reader:
+            return await reader.list_experiment_group_configuration_runs(
+                group_id,
+                project_id,
+                page=page,
+                page_size=page_size,
             )
 
 
@@ -661,6 +784,7 @@ class BackendIntegratedClient:
         # Read-only analytics accessor (lazily exposed via the ``analytics``
         # property). Kept separate from the write paths above.
         self._analytics_ns: AnalyticsNamespace | None = None
+        self._experiment_groups_ns: ExperimentGroupsNamespace | None = None
         self._interaction_policy_cache: dict[
             tuple[str | None, str | None], dict[str, Any]
         ] = {}
@@ -678,6 +802,18 @@ class BackendIntegratedClient:
         if self._analytics_ns is None:
             self._analytics_ns = AnalyticsNamespace(self)
         return self._analytics_ns
+
+    @property
+    def experiment_groups(self) -> "ExperimentGroupsNamespace":
+        """Read-only ``client.experiment_groups`` namespace.
+
+        Provides backend reads for experiment groups/cohorts and their source
+        configuration rows. This namespace performs no writes and does not reuse
+        or mutate active optimization sessions.
+        """
+        if self._experiment_groups_ns is None:
+            self._experiment_groups_ns = ExperimentGroupsNamespace(self)
+        return self._experiment_groups_ns
 
     def _log_local_interaction_policy_once(self) -> None:
         if self._interaction_policy_fallback_logged:

--- a/traigent/cloud/dtos.py
+++ b/traigent/cloud/dtos.py
@@ -12,7 +12,7 @@ from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, cast
 
 from traigent.utils.logging import get_logger
 
@@ -759,6 +759,675 @@ class ConfigurationRunDTO:
             "config": self.metadata.get("config", self.configuration.get("parameters")),
             "dataset_subset": dataset_subset,
         }
+
+
+def _copy_dict(value: Any) -> dict[str, Any]:
+    return deepcopy(value) if isinstance(value, dict) else {}
+
+
+def _copy_list(value: Any) -> list[Any]:
+    return deepcopy(value) if isinstance(value, list) else []
+
+
+def _extra_fields(source: Mapping[str, Any], known: set[str]) -> dict[str, Any]:
+    return {key: deepcopy(value) for key, value in source.items() if key not in known}
+
+
+def _int_or_default(value: Any, default: int) -> int:
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _bool_or_default(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    return bool(value)
+
+
+def _required_str(payload: Mapping[str, Any], key: str, *, dto_name: str) -> str:
+    value = payload.get(key)
+    if value is None or str(value) == "":
+        raise ValueError(f"{dto_name} requires non-empty {key}.")
+    return str(value)
+
+
+@dataclass(frozen=True)
+class ExperimentGroupSourceExperimentDTO:
+    """Source experiment/run member of an experiment group."""
+
+    experiment_id: str
+    experiment_run_id: str | None = None
+    name: str | None = None
+    status: str | None = None
+    dataset_id: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    extra_fields: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(
+        cls, payload: Mapping[str, Any]
+    ) -> "ExperimentGroupSourceExperimentDTO":
+        known = {
+            "experiment_id",
+            "id",
+            "experiment_run_id",
+            "run_id",
+            "name",
+            "status",
+            "dataset_id",
+            "created_at",
+            "updated_at",
+            "metadata",
+        }
+        experiment_id = str(payload.get("experiment_id") or payload.get("id") or "")
+        return cls(
+            experiment_id=experiment_id,
+            experiment_run_id=(
+                str(payload["experiment_run_id"])
+                if payload.get("experiment_run_id") is not None
+                else (
+                    str(payload["run_id"])
+                    if payload.get("run_id") is not None
+                    else None
+                )
+            ),
+            name=str(payload["name"]) if payload.get("name") is not None else None,
+            status=(
+                str(payload["status"]) if payload.get("status") is not None else None
+            ),
+            dataset_id=(
+                str(payload["dataset_id"])
+                if payload.get("dataset_id") is not None
+                else None
+            ),
+            created_at=(
+                str(payload["created_at"])
+                if payload.get("created_at") is not None
+                else None
+            ),
+            updated_at=(
+                str(payload["updated_at"])
+                if payload.get("updated_at") is not None
+                else None
+            ),
+            metadata=_copy_dict(payload.get("metadata")),
+            extra_fields=_extra_fields(payload, known),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        result = deepcopy(self.extra_fields)
+        result.update(
+            {
+                "experiment_id": self.experiment_id,
+                "experiment_run_id": self.experiment_run_id,
+                "name": self.name,
+                "status": self.status,
+                "dataset_id": self.dataset_id,
+                "created_at": self.created_at,
+                "updated_at": self.updated_at,
+                "metadata": deepcopy(self.metadata),
+            }
+        )
+        return result
+
+
+@dataclass(frozen=True)
+class GroupedConfigurationRunRowDTO:
+    """Configuration-run row returned from a grouped/cohort read.
+
+    The three source IDs are intentionally first-class fields. Consumers must
+    join on these IDs, not on tuned variables, objectives, or configuration hash.
+    """
+
+    configuration_run_id: str
+    experiment_run_id: str
+    experiment_id: str
+    configuration: dict[str, Any] = field(default_factory=dict)
+    measures: dict[str, Any] = field(default_factory=dict)
+    status: str | None = None
+    trial_number: int | None = None
+    dataset_id: str | None = None
+    started_at: str | None = None
+    completed_at: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    extra_fields: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "GroupedConfigurationRunRowDTO":
+        known = {
+            "configuration_run_id",
+            "id",
+            "experiment_run_id",
+            "experiment_id",
+            "configuration",
+            "measures",
+            "metrics",
+            "status",
+            "trial_number",
+            "dataset_id",
+            "started_at",
+            "completed_at",
+            "created_at",
+            "updated_at",
+            "metadata",
+        }
+        config_run_id = payload.get("configuration_run_id", payload.get("id"))
+        measures = payload.get("measures", payload.get("metrics"))
+        trial_number = payload.get("trial_number")
+        return cls(
+            configuration_run_id=_required_str(
+                {"configuration_run_id": config_run_id},
+                "configuration_run_id",
+                dto_name="GroupedConfigurationRunRowDTO",
+            ),
+            experiment_run_id=_required_str(
+                payload,
+                "experiment_run_id",
+                dto_name="GroupedConfigurationRunRowDTO",
+            ),
+            experiment_id=_required_str(
+                payload,
+                "experiment_id",
+                dto_name="GroupedConfigurationRunRowDTO",
+            ),
+            configuration=_copy_dict(payload.get("configuration")),
+            measures=_copy_dict(measures),
+            status=(
+                str(payload["status"]) if payload.get("status") is not None else None
+            ),
+            trial_number=(
+                _int_or_default(trial_number, 0) if trial_number is not None else None
+            ),
+            dataset_id=(
+                str(payload["dataset_id"])
+                if payload.get("dataset_id") is not None
+                else None
+            ),
+            started_at=(
+                str(payload["started_at"])
+                if payload.get("started_at") is not None
+                else None
+            ),
+            completed_at=(
+                str(payload["completed_at"])
+                if payload.get("completed_at") is not None
+                else None
+            ),
+            created_at=(
+                str(payload["created_at"])
+                if payload.get("created_at") is not None
+                else None
+            ),
+            updated_at=(
+                str(payload["updated_at"])
+                if payload.get("updated_at") is not None
+                else None
+            ),
+            metadata=_copy_dict(payload.get("metadata")),
+            extra_fields=_extra_fields(payload, known),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        result = deepcopy(self.extra_fields)
+        result.update(
+            {
+                "configuration_run_id": self.configuration_run_id,
+                "experiment_run_id": self.experiment_run_id,
+                "experiment_id": self.experiment_id,
+                "configuration": deepcopy(self.configuration),
+                "measures": deepcopy(self.measures),
+                "status": self.status,
+                "trial_number": self.trial_number,
+                "dataset_id": self.dataset_id,
+                "started_at": self.started_at,
+                "completed_at": self.completed_at,
+                "created_at": self.created_at,
+                "updated_at": self.updated_at,
+                "metadata": deepcopy(self.metadata),
+            }
+        )
+        return result
+
+
+@dataclass(frozen=True)
+class ExperimentGroupStatusSummaryDTO:
+    """Canonical experiment-group status summary."""
+
+    experiment_run_status_counts: dict[str, int] = field(default_factory=dict)
+    configuration_run_status_counts: dict[str, int] = field(default_factory=dict)
+    extra_fields: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(
+        cls, payload: Mapping[str, Any] | None
+    ) -> "ExperimentGroupStatusSummaryDTO":
+        if payload is None:
+            payload = {}
+        known = {
+            "experiment_run_status_counts",
+            "configuration_run_status_counts",
+        }
+        return cls(
+            experiment_run_status_counts={
+                str(key): _int_or_default(value, 0)
+                for key, value in _copy_dict(
+                    payload.get("experiment_run_status_counts")
+                ).items()
+            },
+            configuration_run_status_counts={
+                str(key): _int_or_default(value, 0)
+                for key, value in _copy_dict(
+                    payload.get("configuration_run_status_counts")
+                ).items()
+            },
+            extra_fields=_extra_fields(payload, known),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        result = deepcopy(self.extra_fields)
+        result.update(
+            {
+                "experiment_run_status_counts": dict(self.experiment_run_status_counts),
+                "configuration_run_status_counts": dict(
+                    self.configuration_run_status_counts
+                ),
+            }
+        )
+        return result
+
+
+@dataclass(frozen=True)
+class ExperimentGroupOverviewDTO:
+    """Experiment-group overview row."""
+
+    group_id: str = ""
+    name: str = ""
+    agent_id: str | None = None
+    description: str | None = None
+    project_id: str | None = None
+    dataset_id: str | None = None
+    source_experiments: list[ExperimentGroupSourceExperimentDTO] = field(
+        default_factory=list
+    )
+    experiment_count: int = 0
+    experiment_run_count: int = 0
+    configuration_run_count: int = 0
+    first_experiment_created_at: str | None = None
+    last_experiment_updated_at: str | None = None
+    first_experiment_run_created_at: str | None = None
+    last_experiment_run_updated_at: str | None = None
+    status_summary: ExperimentGroupStatusSummaryDTO = field(
+        default_factory=ExperimentGroupStatusSummaryDTO
+    )
+    created_at: str | None = None
+    updated_at: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    extra_fields: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def configuration_runs_count(self) -> int:
+        """Backward-compatible alias for the canonical singular field."""
+        return self.configuration_run_count
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "ExperimentGroupOverviewDTO":
+        known = {
+            "group_id",
+            "id",
+            "name",
+            "agent_id",
+            "description",
+            "project_id",
+            "dataset_id",
+            "source_experiments",
+            "experiments",
+            "experiment_count",
+            "experiments_count",
+            "experiment_run_count",
+            "experiment_runs_count",
+            "configuration_run_count",
+            "configuration_runs_count",
+            "first_experiment_created_at",
+            "last_experiment_updated_at",
+            "first_experiment_run_created_at",
+            "last_experiment_run_updated_at",
+            "status_summary",
+            "created_at",
+            "updated_at",
+            "metadata",
+        }
+        source_rows = payload.get("source_experiments", payload.get("experiments", []))
+        return cls(
+            group_id=str(payload.get("group_id") or payload.get("id") or ""),
+            name=str(payload.get("name") or ""),
+            agent_id=(
+                str(payload["agent_id"])
+                if payload.get("agent_id") is not None
+                else None
+            ),
+            description=(
+                str(payload["description"])
+                if payload.get("description") is not None
+                else None
+            ),
+            project_id=(
+                str(payload["project_id"])
+                if payload.get("project_id") is not None
+                else None
+            ),
+            dataset_id=(
+                str(payload["dataset_id"])
+                if payload.get("dataset_id") is not None
+                else None
+            ),
+            source_experiments=[
+                ExperimentGroupSourceExperimentDTO.from_dict(item)
+                for item in _copy_list(source_rows)
+                if isinstance(item, Mapping)
+            ],
+            experiment_count=_int_or_default(
+                payload.get("experiment_count", payload.get("experiments_count")),
+                len(_copy_list(source_rows)),
+            ),
+            experiment_run_count=_int_or_default(
+                payload.get(
+                    "experiment_run_count", payload.get("experiment_runs_count")
+                ),
+                0,
+            ),
+            configuration_run_count=_int_or_default(
+                payload.get(
+                    "configuration_run_count",
+                    payload.get("configuration_runs_count"),
+                ),
+                0,
+            ),
+            first_experiment_created_at=(
+                str(payload["first_experiment_created_at"])
+                if payload.get("first_experiment_created_at") is not None
+                else None
+            ),
+            last_experiment_updated_at=(
+                str(payload["last_experiment_updated_at"])
+                if payload.get("last_experiment_updated_at") is not None
+                else None
+            ),
+            first_experiment_run_created_at=(
+                str(payload["first_experiment_run_created_at"])
+                if payload.get("first_experiment_run_created_at") is not None
+                else None
+            ),
+            last_experiment_run_updated_at=(
+                str(payload["last_experiment_run_updated_at"])
+                if payload.get("last_experiment_run_updated_at") is not None
+                else None
+            ),
+            status_summary=ExperimentGroupStatusSummaryDTO.from_dict(
+                payload.get("status_summary")
+                if isinstance(payload.get("status_summary"), Mapping)
+                else None
+            ),
+            created_at=(
+                str(payload["created_at"])
+                if payload.get("created_at") is not None
+                else None
+            ),
+            updated_at=(
+                str(payload["updated_at"])
+                if payload.get("updated_at") is not None
+                else None
+            ),
+            metadata=_copy_dict(payload.get("metadata")),
+            extra_fields=_extra_fields(payload, known),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        result = deepcopy(self.extra_fields)
+        result.update(
+            {
+                "group_id": self.group_id,
+                "name": self.name,
+                "agent_id": self.agent_id,
+                "description": self.description,
+                "project_id": self.project_id,
+                "dataset_id": self.dataset_id,
+                "source_experiments": [
+                    experiment.to_dict() for experiment in self.source_experiments
+                ],
+                "experiment_count": self.experiment_count,
+                "experiment_run_count": self.experiment_run_count,
+                "configuration_run_count": self.configuration_run_count,
+                "first_experiment_created_at": self.first_experiment_created_at,
+                "last_experiment_updated_at": self.last_experiment_updated_at,
+                "first_experiment_run_created_at": self.first_experiment_run_created_at,
+                "last_experiment_run_updated_at": self.last_experiment_run_updated_at,
+                "status_summary": self.status_summary.to_dict(),
+                "created_at": self.created_at,
+                "updated_at": self.updated_at,
+                "metadata": deepcopy(self.metadata),
+            }
+        )
+        return result
+
+
+@dataclass(frozen=True)
+class ExperimentGroupDetailDTO(ExperimentGroupOverviewDTO):
+    """Detailed experiment group, including grouped configuration rows."""
+
+    grouped_configurations: list[GroupedConfigurationRunRowDTO] = field(
+        default_factory=list
+    )
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "ExperimentGroupDetailDTO":
+        if isinstance(payload.get("group"), Mapping):
+            overview_payload = dict(cast(Mapping[str, Any], payload["group"]))
+            if "source_experiments" not in overview_payload:
+                overview_payload["source_experiments"] = payload.get(
+                    "source_experiments",
+                    [],
+                )
+        else:
+            overview_payload = dict(payload)
+
+        overview = ExperimentGroupOverviewDTO.from_dict(overview_payload)
+        rows = payload.get(
+            "grouped_configurations",
+            payload.get("configuration_runs", payload.get("configurations", [])),
+        )
+        extra = dict(overview.extra_fields)
+        for key in (
+            "group",
+            "source_experiments",
+            "grouped_configurations",
+            "configuration_runs",
+            "configurations",
+        ):
+            extra.pop(key, None)
+        return cls(
+            group_id=overview.group_id,
+            name=overview.name,
+            agent_id=overview.agent_id,
+            description=overview.description,
+            project_id=overview.project_id,
+            dataset_id=overview.dataset_id,
+            source_experiments=overview.source_experiments,
+            experiment_count=overview.experiment_count,
+            experiment_run_count=overview.experiment_run_count,
+            configuration_run_count=overview.configuration_run_count,
+            first_experiment_created_at=overview.first_experiment_created_at,
+            last_experiment_updated_at=overview.last_experiment_updated_at,
+            first_experiment_run_created_at=overview.first_experiment_run_created_at,
+            last_experiment_run_updated_at=overview.last_experiment_run_updated_at,
+            status_summary=overview.status_summary,
+            created_at=overview.created_at,
+            updated_at=overview.updated_at,
+            metadata=overview.metadata,
+            extra_fields=extra,
+            grouped_configurations=[
+                GroupedConfigurationRunRowDTO.from_dict(item)
+                for item in _copy_list(rows)
+                if isinstance(item, Mapping)
+            ],
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        result = super().to_dict()
+        result["grouped_configurations"] = [
+            row.to_dict() for row in self.grouped_configurations
+        ]
+        return result
+
+
+@dataclass(frozen=True)
+class ExperimentGroupsPageDTO:
+    """Paginated experiment-group overview response."""
+
+    items: list[ExperimentGroupOverviewDTO]
+    page: int = 1
+    page_size: int = 50
+    total: int = 0
+    total_pages: int = 0
+    has_next: bool = False
+    has_previous: bool = False
+    extra_fields: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "ExperimentGroupsPageDTO":
+        known = {
+            "items",
+            "experiment_groups",
+            "groups",
+            "page",
+            "page_size",
+            "per_page",
+            "total",
+            "total_items",
+            "total_pages",
+            "has_next",
+            "has_previous",
+            "has_prev",
+        }
+        rows = payload.get(
+            "items", payload.get("experiment_groups", payload.get("groups", []))
+        )
+        page_size = _int_or_default(
+            payload.get("page_size", payload.get("per_page")), 50
+        )
+        return cls(
+            items=[
+                ExperimentGroupOverviewDTO.from_dict(item)
+                for item in _copy_list(rows)
+                if isinstance(item, Mapping)
+            ],
+            page=_int_or_default(payload.get("page"), 1),
+            page_size=page_size,
+            total=_int_or_default(payload.get("total", payload.get("total_items")), 0),
+            total_pages=_int_or_default(payload.get("total_pages"), 0),
+            has_next=_bool_or_default(payload.get("has_next"), False),
+            has_previous=_bool_or_default(
+                payload.get("has_previous", payload.get("has_prev")),
+                False,
+            ),
+            extra_fields=_extra_fields(payload, known),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        result = deepcopy(self.extra_fields)
+        result.update(
+            {
+                "items": [item.to_dict() for item in self.items],
+                "page": self.page,
+                "page_size": self.page_size,
+                "total": self.total,
+                "total_pages": self.total_pages,
+                "has_next": self.has_next,
+                "has_previous": self.has_previous,
+            }
+        )
+        return result
+
+
+@dataclass(frozen=True)
+class GroupedConfigurationRunsPageDTO:
+    """Paginated grouped configuration-run response."""
+
+    items: list[GroupedConfigurationRunRowDTO]
+    page: int = 1
+    page_size: int = 50
+    total: int = 0
+    total_pages: int = 0
+    has_next: bool = False
+    has_previous: bool = False
+    extra_fields: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "GroupedConfigurationRunsPageDTO":
+        known = {
+            "items",
+            "configuration_runs",
+            "grouped_configurations",
+            "rows",
+            "page",
+            "page_size",
+            "per_page",
+            "total",
+            "total_items",
+            "total_pages",
+            "has_next",
+            "has_previous",
+            "has_prev",
+        }
+        rows = payload.get(
+            "items",
+            payload.get(
+                "configuration_runs",
+                payload.get("grouped_configurations", payload.get("rows", [])),
+            ),
+        )
+        page_size = _int_or_default(
+            payload.get("page_size", payload.get("per_page")), 50
+        )
+        return cls(
+            items=[
+                GroupedConfigurationRunRowDTO.from_dict(item)
+                for item in _copy_list(rows)
+                if isinstance(item, Mapping)
+            ],
+            page=_int_or_default(payload.get("page"), 1),
+            page_size=page_size,
+            total=_int_or_default(payload.get("total", payload.get("total_items")), 0),
+            total_pages=_int_or_default(payload.get("total_pages"), 0),
+            has_next=_bool_or_default(payload.get("has_next"), False),
+            has_previous=_bool_or_default(
+                payload.get("has_previous", payload.get("has_prev")),
+                False,
+            ),
+            extra_fields=_extra_fields(payload, known),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        result = deepcopy(self.extra_fields)
+        result.update(
+            {
+                "items": [item.to_dict() for item in self.items],
+                "page": self.page,
+                "page_size": self.page_size,
+                "total": self.total,
+                "total_pages": self.total_pages,
+                "has_next": self.has_next,
+                "has_previous": self.has_previous,
+            }
+        )
+        return result
 
 
 @dataclass


### PR DESCRIPTION
Spine: cs_1881b4f433af237a

## Summary
- Add Python SDK DTO/client support for experiment groups, group detail, and grouped configuration-run rows.
- Require explicit `project_id` for all new experiment-group reads and send it via `X-Project-Id`.
- Preserve source `configuration_run_id`, `experiment_run_id`, and `experiment_id`; no client-side grouping/deduping.

## Related PRs
- Schema: https://github.com/Traigent/TraigentSchema/pull/260
- Backend: https://github.com/Traigent/TraigentBackend/pull/1854

## Validation
- `python3 -m compileall -q traigent/cloud` — passed.
- `pytest -q -n0 tests/unit/cloud/test_analytics_client.py tests/unit/cloud/test_experiment_groups_client.py tests/unit/cloud/test_backend_client.py::TestBackendIntegratedClient::test_experiment_groups_facade_uses_read_client tests/unit/cloud/test_backend_client.py::TestBackendIntegratedClient::test_analytics_experiment_groups_alias_forwards_filters` — 53 passed, 1 skipped.
- `pytest -q -n0 tests/unit/cloud/test_dtos.py tests/unit/cloud/test_experiment_groups_client.py` — 93 passed.
- `ruff check traigent/cloud/dtos.py traigent/cloud/analytics_client.py traigent/cloud/backend_client.py traigent/cloud/__init__.py tests/unit/cloud/test_experiment_groups_client.py tests/unit/cloud/test_backend_client.py` — passed.
- `git diff --check` — passed.
- Claude Opus xhigh final review — PASS (`/tmp/claude-review-python-final2.json`).

## Production Safety Checklist
1. Worst-case prod path: unscoped reads could expose project data; new methods require non-empty `project_id` and use `X-Project-Id`.
2. Production-branch test: SDK unit tests assert missing/blank project ids fail before HTTP calls.
3. Contract regeneration: depends on schema PR #260 and backend PR #1854.
4. Public surface delta: additive SDK DTOs/client methods/facades for experiment groups.
5. Review threads resolved: no review threads yet at PR creation; will resolve all before merge.
6. Quality gates not relaxed: no gate thresholds changed.

## Notes
- Local commit hook mypy was skipped only because repo-wide mypy fails on `origin/develop` with the same unrelated baseline errors; focused compile/tests/ruff passed.
- Spine posture remains stale/global-blocked, so this PR does not claim release readiness.
- Claude Opus xhigh final follow-up review — PASS (`/tmp/claude-review-python-final3.json`).