### PR TITLE
fix(sdk): thread real per-example accuracy into smart-pruning progress (D1, live-e2e fix)

### DIFF
--- a/tests/unit/core/test_trial_lifecycle.py
+++ b/tests/unit/core/test_trial_lifecycle.py
@@ -35,6 +35,7 @@ from traigent.evaluators.base import (
     EvaluationExample,
     EvaluationResult,
 )
+from traigent.evaluators.local import LocalEvaluator
 from traigent.optimizers.base import BaseOptimizer
 from traigent.utils.exceptions import TrialPrunedError
 
@@ -385,7 +386,9 @@ class TestCreateProgressTracking:
         assert manager.reports == []
 
     @pytest.mark.asyncio
-    async def test_cloud_smart_pruning_posts_and_returns_pruned_result(self):
+    async def test_cloud_smart_pruning_posts_and_returns_pruned_result(
+        self, caplog: pytest.LogCaptureFixture
+    ):
         """prune=true stops the trial and preserves partial example results."""
         orchestrator = MockOrchestrator()
         orchestrator.evaluator = SmartPruningEvaluator()
@@ -394,16 +397,20 @@ class TestCreateProgressTracking:
         lifecycle = TrialLifecycle(orchestrator)
         dataset = create_real_dataset(size=3)
 
-        result = await lifecycle.run_trial(
-            func=lambda value: value,
-            config={"temperature": 0.2},
-            dataset=dataset,
-            trial_number=1,
-            session_id="session-123",
-        )
+        with caplog.at_level("INFO", logger="traigent.core.trial_lifecycle"):
+            result = await lifecycle.run_trial(
+                func=lambda value: value,
+                config={"temperature": 0.2},
+                dataset=dataset,
+                trial_number=1,
+                session_id="session-123",
+            )
 
         assert result.status == TrialStatus.PRUNED
         assert result.error_message == "running score below smart-pruning threshold"
+        assert "running score below smart-pruning threshold" in " ".join(
+            record.getMessage() for record in caplog.records
+        )
         assert result.metadata["pruned"] is True
         assert result.metadata["examples_attempted"] == 2
         assert len(result.metadata["example_results"]) == 2
@@ -419,6 +426,74 @@ class TestCreateProgressTracking:
         assert manager.reports[1]["examples_attempted"] == 2
         assert manager.reports[1]["running_score"] == 0.5
         assert "output" not in manager.reports[0]
+
+    @pytest.mark.asyncio
+    async def test_cloud_smart_pruning_uses_real_per_example_accuracy(self):
+        """Real evaluator progress reports true partial accuracy, not success rate."""
+        orchestrator = MockOrchestrator()
+        orchestrator.evaluator = LocalEvaluator(metrics=["accuracy"], detailed=False)
+        manager = RecordingSmartPruningManager(prune_after=4)
+        orchestrator.backend_session_manager = manager
+        lifecycle = TrialLifecycle(orchestrator)
+        dataset = Dataset(
+            examples=[
+                EvaluationExample(
+                    input_data={"question": "secret prompt one"},
+                    expected_output="correct-a",
+                ),
+                EvaluationExample(
+                    input_data={"question": "secret prompt two"},
+                    expected_output="correct-b",
+                ),
+                EvaluationExample(
+                    input_data={"question": "secret prompt three"},
+                    expected_output="correct-c",
+                ),
+                EvaluationExample(
+                    input_data={"question": "secret prompt four"},
+                    expected_output="correct-d",
+                ),
+            ],
+            name="smart-pruning-accuracy",
+        )
+        outputs: dict[str, str] = {
+            "secret prompt one": "correct-a",
+            "secret prompt two": "wrong-b",
+            "secret prompt three": "correct-c",
+            "secret prompt four": "correct-d",
+        }
+
+        def answer(question: str) -> str:
+            return outputs[question]
+
+        result = await lifecycle.run_trial(
+            func=answer,
+            config={"temperature": 0.2},
+            dataset=dataset,
+            trial_number=1,
+            session_id="session-123",
+        )
+
+        allowed_keys = {
+            "session_id",
+            "trial_id",
+            "running_score",
+            "examples_attempted",
+            "objective_name",
+            "partial_cost_usd",
+        }
+        assert result.status == TrialStatus.PRUNED
+        assert result.error_message == "running score below smart-pruning threshold"
+        assert result.metrics["accuracy"] == pytest.approx(0.75)
+        assert result.metrics["examples_attempted"] == 4
+        assert result.metadata["examples_attempted"] == 4
+        assert manager.reports[-1]["running_score"] == pytest.approx(0.75)
+        assert manager.reports[-1]["examples_attempted"] == 4
+        assert all(set(report) <= allowed_keys for report in manager.reports)
+        reports_text = str(manager.reports)
+        assert "secret prompt" not in reports_text
+        assert "correct-" not in reports_text
+        assert "wrong-b" not in reports_text
 
     @pytest.mark.asyncio
     async def test_cloud_smart_pruning_report_failure_continues_trial(

--- a/traigent/core/trial_lifecycle.py
+++ b/traigent/core/trial_lifecycle.py
@@ -761,6 +761,11 @@ class TrialLifecycle:
             decision = report(payload) if callable(report) else {}
             if isinstance(decision, dict) and decision.get("prune") is True:
                 reason = decision.get("prune_reason") or "cloud smart pruning"
+                logger.info(
+                    "Cloud smart pruning requested trial pruning after %s examples: %s",
+                    state["evaluated"],
+                    reason,
+                )
                 raise TrialPrunedError(str(reason), step=int(state["evaluated"]))
 
         return _progress_callback, state

--- a/traigent/evaluators/base.py
+++ b/traigent/evaluators/base.py
@@ -1610,7 +1610,10 @@ class BaseEvaluator(ABC):
 
         if progress_callback:
             progress_callback(
-                index, {"success": error is None, "output": output, "error": error}
+                index,
+                self._build_non_detailed_progress_payload(
+                    example, index, output, error
+                ),
             )
 
         return output, error
@@ -1727,6 +1730,7 @@ class BaseEvaluator(ABC):
         detailed: bool,
         progress_callback: Callable[[int, dict[str, Any]], Any] | None,
         index: int,
+        example: EvaluationExample,
         outputs: list[Any],
         errors: list[str | None],
         example_results: list[ExampleResult | None],
@@ -1742,7 +1746,10 @@ class BaseEvaluator(ABC):
             errors.append(error)
             if progress_callback:
                 progress_callback(
-                    index, {"success": error is None, "output": output, "error": error}
+                    index,
+                    self._build_non_detailed_progress_payload(
+                        example, index, output, error
+                    ),
                 )
 
     async def _handle_task_result(
@@ -1813,6 +1820,7 @@ class BaseEvaluator(ABC):
             result,
             detailed,
             progress_callback,
+            examples[index],
             outputs_by_index,
             errors_by_index,
             example_results_by_index,
@@ -1845,6 +1853,7 @@ class BaseEvaluator(ABC):
         result: Any,
         detailed: bool,
         progress_callback: Callable[[int, dict[str, Any]], Any] | None,
+        example: EvaluationExample,
         outputs_by_index: dict[int, Any],
         errors_by_index: dict[int, str | None],
         example_results_by_index: dict[int, ExampleResult | None],
@@ -1864,7 +1873,9 @@ class BaseEvaluator(ABC):
                 # Note: This is sync in the original, we handle exceptions elsewhere
                 progress_callback(
                     index,
-                    {"success": error is None, "output": output, "error": error},
+                    self._build_non_detailed_progress_payload(
+                        example, index, output, error
+                    ),
                 )
 
     async def _safe_progress_callback(
@@ -2229,35 +2240,73 @@ class BaseEvaluator(ABC):
         error: str | None,
     ) -> dict[str, Any]:
         """Build progress callback payload with metrics."""
-        metrics_payload: dict[str, float] = {}
-
-        if error is None and example.expected_output is not None:
-            try:
-                metrics_payload["accuracy"] = (
-                    1.0
-                    if _accuracy_values_match(
-                        result.actual_output, example.expected_output
-                    )
-                    else 0.0
-                )
-            except Exception as exc:
-                logger.warning(
-                    "Failed to compute accuracy metric for example %s: %s",
-                    example_id,
-                    exc,
-                )
+        metrics_payload = self._build_progress_accuracy_metrics(
+            output=result.actual_output,
+            expected_output=example.expected_output,
+            error=error,
+            example_id=example_id,
+        )
 
         metrics_update, _ = self._extract_response_metrics(
             example_id, example, result, config
         )
         metrics_payload.update(metrics_update)
 
-        return {
+        payload: dict[str, Any] = {
             "success": result.success,
             "error": result.error_message,
-            "metrics": metrics_payload,
             "output": result.actual_output,
         }
+        if metrics_payload:
+            payload["metrics"] = metrics_payload
+        return payload
+
+    def _build_progress_accuracy_metrics(
+        self,
+        *,
+        output: Any,
+        expected_output: Any,
+        error: str | None,
+        example_id: str,
+    ) -> dict[str, float]:
+        """Return per-example accuracy using the same comparator as aggregate accuracy."""
+        if error is not None or _is_empty_expected_output(expected_output):
+            return {}
+        try:
+            return {
+                "accuracy": (
+                    1.0 if _accuracy_values_match(output, expected_output) else 0.0
+                )
+            }
+        except Exception as exc:
+            logger.warning(
+                "Failed to compute accuracy metric for example %s: %s",
+                example_id,
+                exc,
+            )
+            return {}
+
+    def _build_non_detailed_progress_payload(
+        self,
+        example: EvaluationExample,
+        index: int,
+        output: Any,
+        error: str | None,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "success": error is None,
+            "output": output,
+            "error": error,
+        }
+        metrics_payload = self._build_progress_accuracy_metrics(
+            output=output,
+            expected_output=example.expected_output,
+            error=error,
+            example_id=_example_correlation_key(example, index),
+        )
+        if metrics_payload:
+            payload["metrics"] = metrics_payload
+        return payload
 
     def _record_example_trace(
         self,


### PR DESCRIPTION
## Summary

Follow-up to the smart-pruning wiring (#1589) — the **live SDK↔backend e2e** (dev7 vs real api-dev) found that smart-pruning pruned a **good** config because the streamed `running_score` was degenerate.

**Root cause:** every per-example `progress_callback` emitted only `{success=no-exception, output, error}` — `success` is "the function didn't raise", **not** "the answer was correct". Per-example grading ran only in a later aggregate pass, so the report consumer (`trial_lifecycle._extract_progress_value`) found no graded metric and fell back to a grading-free signal → the backend pruned on noise.

**Fix (SDK producer only):**
- `evaluators/base.py`: the 3 success-path per-example callbacks now compute per-example accuracy via the **same** `_accuracy_values_match` comparator the aggregate scorer uses (shared `_build_progress_accuracy_metrics`), guarded by `_is_empty_expected_output`/`error is None` (no fabricated 0.0/1.0). `running_score` and `build_pruned_result` `metrics["accuracy"]` now reflect **true partial accuracy**.
- `trial_lifecycle.py`: surface the real backend `prune_reason` in a log line (observability; control flow unchanged).

## PR checklist
1. **Worst-case prod path:** the intermediate-report POST body is built separately and carries only `{session_id, trial_id, running_score, examples_attempted, optional objective_name/partial_cost_usd}` — the new path adds a **float** only; raw `output`/`expected` stay in the internal callback dict consumed locally and **never reach the wire**. Report transport errors fail safe (no abort).
2. **Production-branch test:** `tests/unit/core/test_trial_lifecycle.py` asserts (a) 3-of-4 partial accuracy → `running_score==0.75` and pruned `metrics["accuracy"]==0.75`, and (b) report payloads ⊆ allowed keys with **no leaked content** (secret prompt / expected / wrong-output strings absent).
3. **Contract regeneration:** none — uses the existing `intermediate_report_schema`. No Schema/JS change.
4. **Public surface delta:** none (internal evaluator + report producer; inert unless `smart_pruning` is enabled on a managed/cloud run).
5. **Review threads:** will resolve all before merge.
6. **Quality gates:** not relaxed. Full unit suite **13,912 passed** (captain re-run, isolated venv); ruff clean; mypy clean on the 2 changed files.

Independent cross-model review (fresh Claude Opus xhigh): **GO** (content-free hard gate PASS).

Spine: cs_4ea49f57dc2b65c9
Spine-Trail: st_e86bc9463866