### PR TITLE
fix(sdk): smart-pruning correctness + cloud-completion durability (D1-proper + D3, live-e2e confirmed)

### DIFF
--- a/tests/unit/cloud/test_trial_operations.py
+++ b/tests/unit/cloud/test_trial_operations.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from traigent.cloud.trial_operations import TrialOperations
+from traigent.cloud.trial_operations import TrialOperations, TrialSlotResult
 
 
 class TestRedactSensitiveFields:
@@ -851,17 +851,17 @@ class TestRequestTrialSlot:
         ):
             mock_aiohttp.ClientSession = Mock(return_value=mock_session_ctx)
             mock_aiohttp.ClientTimeout = Mock()
-            trial_id = await ops.request_trial_slot("sess-1")
+            slot = await ops.request_trial_slot("sess-1")
 
-        assert trial_id == "trial_be_minted_abc"
+        assert slot == TrialSlotResult.acquired("trial_be_minted_abc")
+        assert slot
         # It hit the next-trial endpoint (where the backend mints the slot).
         url = mock_session.post.call_args.args[0]
         assert url.endswith("/sessions/sess-1/next-trial")
 
     @pytest.mark.asyncio
-    async def test_returns_none_when_no_suggestion(self) -> None:
-        """Backend declines to suggest a further trial ⇒ None (fail closed;
-        never fabricate a client id)."""
+    async def test_should_continue_false_returns_completion_result(self) -> None:
+        """Graceful backend completion is distinct from genuine no-slot/error."""
         ops = TrialOperations(_mk_slot_client())
 
         mock_response = Mock()
@@ -881,15 +881,21 @@ class TestRequestTrialSlot:
         ):
             mock_aiohttp.ClientSession = Mock(return_value=mock_session_ctx)
             mock_aiohttp.ClientTimeout = Mock()
-            assert await ops.request_trial_slot("sess-1") is None
+            slot = await ops.request_trial_slot("sess-1")
+
+        assert slot == TrialSlotResult.complete()
+        assert not slot
 
     @pytest.mark.asyncio
-    async def test_returns_none_on_non_2xx(self) -> None:
+    async def test_should_continue_true_without_id_returns_unavailable(self) -> None:
+        """A malformed/empty continuation response is not terminal completion."""
         ops = TrialOperations(_mk_slot_client())
 
         mock_response = Mock()
-        mock_response.status = 404
-        mock_response.text = AsyncMock(return_value="not found")
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={"should_continue": True, "suggestion": {}}
+        )
         mock_session_ctx, _ = _aiohttp_post_returning(mock_response)
 
         with (
@@ -902,10 +908,56 @@ class TestRequestTrialSlot:
         ):
             mock_aiohttp.ClientSession = Mock(return_value=mock_session_ctx)
             mock_aiohttp.ClientTimeout = Mock()
-            assert await ops.request_trial_slot("sess-1") is None
+            slot = await ops.request_trial_slot("sess-1")
+
+        assert slot == TrialSlotResult.unavailable()
+        assert not slot.optimization_complete
 
     @pytest.mark.asyncio
-    async def test_returns_none_in_offline_mode(self) -> None:
+    async def test_non_2xx_returns_unavailable(self) -> None:
+        ops = TrialOperations(_mk_slot_client())
+
+        mock_response = Mock()
+        mock_response.status = 500
+        mock_response.text = AsyncMock(return_value="server error")
+        mock_session_ctx, _ = _aiohttp_post_returning(mock_response)
+
+        with (
+            patch(
+                "traigent.cloud.trial_operations.is_backend_offline",
+                return_value=False,
+            ),
+            patch("traigent.cloud.trial_operations.AIOHTTP_AVAILABLE", True),
+            patch("traigent.cloud.trial_operations.aiohttp") as mock_aiohttp,
+        ):
+            mock_aiohttp.ClientSession = Mock(return_value=mock_session_ctx)
+            mock_aiohttp.ClientTimeout = Mock()
+            slot = await ops.request_trial_slot("sess-1")
+
+        assert slot == TrialSlotResult.unavailable()
+        assert not slot.optimization_complete
+
+    @pytest.mark.asyncio
+    async def test_transport_error_returns_unavailable(self) -> None:
+        ops = TrialOperations(_mk_slot_client())
+
+        with (
+            patch(
+                "traigent.cloud.trial_operations.is_backend_offline",
+                return_value=False,
+            ),
+            patch("traigent.cloud.trial_operations.AIOHTTP_AVAILABLE", True),
+            patch("traigent.cloud.trial_operations.aiohttp") as mock_aiohttp,
+        ):
+            mock_aiohttp.ClientSession = Mock(side_effect=ConnectionError("boom"))
+            mock_aiohttp.ClientTimeout = Mock()
+            slot = await ops.request_trial_slot("sess-1")
+
+        assert slot == TrialSlotResult.unavailable()
+        assert not slot.optimization_complete
+
+    @pytest.mark.asyncio
+    async def test_offline_mode_returns_unavailable(self) -> None:
         """Offline mode skips the backend entirely (no fake slot)."""
         mock_client = _mk_slot_client()
         ops = TrialOperations(mock_client)
@@ -913,7 +965,8 @@ class TestRequestTrialSlot:
             "traigent.cloud.trial_operations.is_backend_offline",
             return_value=True,
         ):
-            assert await ops.request_trial_slot("sess-1") is None
+            slot = await ops.request_trial_slot("sess-1")
+        assert slot == TrialSlotResult.unavailable()
         mock_client.auth_manager.augment_headers.assert_not_awaited()
 
 

--- a/tests/unit/core/test_backend_session_manager.py
+++ b/tests/unit/core/test_backend_session_manager.py
@@ -20,8 +20,12 @@ from traigent.cloud.session_types import (
     SessionCreationFailureReason,
     SessionCreationResult,
 )
+from traigent.cloud.trial_operations import TrialSlotResult
 from traigent.config.types import TraigentConfig
-from traigent.core.backend_session_manager import BackendSessionManager
+from traigent.core.backend_session_manager import (
+    BackendSessionManager,
+    BackendTrialSubmissionOutcome,
+)
 from traigent.core.objectives import create_default_objectives
 from traigent.evaluators.base import Dataset, EvaluationExample
 from traigent.storage.local_storage import LocalStorageManager
@@ -430,7 +434,11 @@ class TestBackendSessionManagerTrialSubmission:
 
     @pytest.mark.asyncio
     async def test_submit_trial_fails_closed_when_no_backend_slot(
-        self, backend_session_manager, mock_trial_result, mock_backend_client
+        self,
+        backend_session_manager,
+        mock_trial_result,
+        mock_backend_client,
+        traigent_config,
     ):
         """When the backend declines to mint a trial slot (next-trial returns
         no id), the manager MUST NOT submit a result under a client-hashed id
@@ -452,6 +460,59 @@ class TestBackendSessionManagerTrialSubmission:
         assert not backend_session_manager.is_trial_backend_acknowledged(
             "test-session-id", original_id
         )
+        assert backend_session_manager.backend_degraded is True
+        assert traigent_config.result_source == "local_fallback"
+
+    @pytest.mark.asyncio
+    async def test_submit_trial_completion_slot_does_not_degrade(
+        self,
+        backend_session_manager,
+        mock_trial_result,
+        mock_backend_client,
+        traigent_config,
+    ):
+        """Graceful should_continue=False is terminal completion, not outage."""
+        mock_backend_client.request_trial_slot = AsyncMock(
+            return_value=TrialSlotResult.complete("converged")
+        )
+        degrade = Mock(wraps=backend_session_manager._flag_backend_degraded)
+        backend_session_manager._flag_backend_degraded = degrade
+
+        outcome = await backend_session_manager.submit_trial(
+            trial_result=mock_trial_result,
+            session_id="test-session-id",
+        )
+
+        assert isinstance(outcome, BackendTrialSubmissionOutcome)
+        assert outcome.optimization_complete is True
+        assert outcome.reason == "converged"
+        degrade.assert_not_called()
+        mock_backend_client._submit_trial_result_via_session.assert_not_called()
+        assert backend_session_manager.backend_degraded is False
+        assert traigent_config.result_source != "local_fallback"
+
+    @pytest.mark.asyncio
+    async def test_submit_trial_connectivity_slot_failure_still_degrades(
+        self,
+        backend_session_manager,
+        mock_trial_result,
+        mock_backend_client,
+        traigent_config,
+    ):
+        """Transport failure remains the existing local-fallback path."""
+        mock_backend_client.request_trial_slot = AsyncMock(
+            side_effect=ConnectionError("network down")
+        )
+
+        result = await backend_session_manager.submit_trial(
+            trial_result=mock_trial_result,
+            session_id="test-session-id",
+        )
+
+        assert result is True
+        mock_backend_client._submit_trial_result_via_session.assert_not_called()
+        assert backend_session_manager.backend_degraded is True
+        assert traigent_config.result_source == "local_fallback"
 
     @pytest.mark.asyncio
     async def test_submission_carries_only_the_tuned_projection(
@@ -600,6 +661,38 @@ class TestBackendSessionManagerTrialSubmission:
         mock_backend_client._submit_trial_result_via_session.assert_called_once()
         call_kwargs = mock_backend_client._submit_trial_result_via_session.call_args
         assert call_kwargs.kwargs["status"] == "PRUNED"
+
+    @pytest.mark.asyncio
+    async def test_pruned_trial_with_acquired_backend_id_reuses_slot(
+        self, backend_session_manager, mock_backend_client
+    ):
+        """A pruned result from a backend-id config must not burn another slot."""
+        pruned_trial = Mock(spec=TrialResult)
+        pruned_trial.trial_id = "be-pruned-456"
+        pruned_trial.config = {"param1": 1}
+        pruned_trial.metrics = {"accuracy": 0.7, "cost": 0.3}
+        pruned_trial.is_successful = False
+        pruned_trial.status = TrialStatus.PRUNED
+        pruned_trial.duration = 0.5
+        pruned_trial.error_message = "Early stopping triggered"
+        pruned_trial.metadata = {
+            "pruned": True,
+            "backend_trial_id_acquired": True,
+            "backend_trial_id_source": "cloud_brain",
+        }
+        pruned_trial.get_metric = Mock(
+            side_effect=lambda key, default=None: pruned_trial.metrics.get(key, default)
+        )
+
+        await backend_session_manager.submit_trial(
+            trial_result=pruned_trial,
+            session_id="test-session-id",
+        )
+
+        mock_backend_client.request_trial_slot.assert_not_called()
+        kwargs = mock_backend_client._submit_trial_result_via_session.call_args.kwargs
+        assert kwargs["trial_id"] == "be-pruned-456"
+        assert kwargs["status"] == "PRUNED"
 
     @pytest.mark.asyncio
     async def test_submit_trial_metrics_keys_are_measuresdict_compatible(

--- a/tests/unit/core/test_orchestrator.py
+++ b/tests/unit/core/test_orchestrator.py
@@ -443,6 +443,7 @@ class TestOptimizationOrchestrator:
 
             result = await orchestrator.optimize(mock_function, sample_dataset)
 
+        assert isinstance(result, OptimizationResult)
         assert result.status == OptimizationStatus.COMPLETED
         assert result.stop_reason == "max_trials_reached"
         assert [trial.status for trial in result.trials] == [

--- a/tests/unit/core/test_orchestrator.py
+++ b/tests/unit/core/test_orchestrator.py
@@ -33,6 +33,7 @@ from traigent.api.types import (
     TrialStatus,
 )
 from traigent.config.types import TraigentConfig
+from traigent.core.backend_session_manager import BackendTrialSubmissionOutcome
 from traigent.core.objectives import ObjectiveDefinition, ObjectiveSchema
 from traigent.core.orchestrator import OptimizationOrchestrator
 from traigent.core.orchestrator_helpers import allocate_parallel_ceilings
@@ -481,6 +482,77 @@ class TestOptimizationOrchestrator:
 
             with pytest.raises(OptimizationError, match="transport failure"):
                 await orchestrator.optimize(mock_function, sample_dataset)
+
+    @pytest.mark.asyncio
+    async def test_submission_completion_finalizes_cloud_result_with_pruned_trial(
+        self,
+        config_space,
+        objectives,
+        mock_function,
+        sample_dataset,
+        monkeypatch,
+    ):
+        """Submission-time completion breaks the loop without local fallback."""
+        monkeypatch.delenv("TRAIGENT_OFFLINE", raising=False)
+        monkeypatch.delenv("TRAIGENT_OFFLINE_MODE", raising=False)
+        optimizer = MockOptimizer(config_space, objectives)
+        evaluator = PruningModeEvaluator()
+
+        with patch(
+            "traigent.cloud.backend_client.BackendIntegratedClient"
+        ) as mock_backend:
+            mock_client = MagicMock()
+            mock_client.create_session.return_value = "test_session_123"
+            mapping = MagicMock()
+            mapping.experiment_id = "exp_submission_complete"
+            mapping.experiment_run_id = "run_submission_complete"
+            mock_client.get_session_mapping.return_value = mapping
+            mock_backend.return_value = mock_client
+
+            orchestrator = OptimizationOrchestrator(
+                optimizer=optimizer,
+                evaluator=evaluator,
+                max_trials=5,
+                timeout=5.0,
+                default_config={"param1": 1, "mode": "prune"},
+            )
+            orchestrator.backend_client = mock_client
+            orchestrator.traigent_config.execution_mode = "hybrid"
+            orchestrator.traigent_config.result_source = "cloud_brain"
+            orchestrator.traigent_config.fallback_reason = None
+            orchestrator.traigent_config.no_egress = False
+            orchestrator._submit_usage_analytics = AsyncMock()
+            orchestrator._workflow_trace_manager.submit_traces = AsyncMock()
+
+            manager = orchestrator.backend_session_manager
+            manager._backend_tracking_enabled = True
+            manager._runtime_degraded = False
+            manager._no_egress = False
+            manager._acknowledged_trials.add(("test_session_123", "previous-trial"))
+            manager.submit_trial = AsyncMock(
+                return_value=BackendTrialSubmissionOutcome.complete("converged")
+            )
+            manager.update_weighted_scores = AsyncMock(return_value=0)
+            manager.submit_session_aggregation = MagicMock()
+            manager.finalize_session = MagicMock(
+                return_value={"status": "completed", "metadata": {}}
+            )
+
+            result = await orchestrator.optimize(mock_function, sample_dataset)
+
+        assert result.status == OptimizationStatus.COMPLETED
+        manager.submit_trial.assert_awaited_once()
+        manager.finalize_session.assert_called_once()
+        assert result.stop_reason == "convergence"
+        assert result.source == "cloud_brain"
+        assert result.metadata["source"] == "cloud_brain"
+        assert result.experiment_id == "exp_submission_complete"
+        assert result.experiment_run_id == "run_submission_complete"
+        assert result.cloud_url is not None
+        assert "exp_submission_complete" in result.cloud_url
+        assert len(result.trials) == 1
+        assert result.trials[0].status == TrialStatus.PRUNED
+        assert orchestrator.traigent_config.result_source == "cloud_brain"
 
     @pytest.mark.asyncio
     async def test_default_config_is_evaluated_first(

--- a/tests/unit/core/test_orchestrator.py
+++ b/tests/unit/core/test_orchestrator.py
@@ -34,9 +34,11 @@ from traigent.api.types import (
 )
 from traigent.config.types import TraigentConfig
 from traigent.core.backend_session_manager import BackendTrialSubmissionOutcome
+from traigent.core.cost_enforcement import Permit
 from traigent.core.objectives import ObjectiveDefinition, ObjectiveSchema
 from traigent.core.orchestrator import OptimizationOrchestrator
 from traigent.core.orchestrator_helpers import allocate_parallel_ceilings
+from traigent.core.parallel_execution_manager import PermittedTrialResult
 from traigent.evaluators.base import (
     BaseEvaluator,
     Dataset,
@@ -553,6 +555,125 @@ class TestOptimizationOrchestrator:
         assert len(result.trials) == 1
         assert result.trials[0].status == TrialStatus.PRUNED
         assert orchestrator.traigent_config.result_source == "cloud_brain"
+
+    @pytest.mark.asyncio
+    async def test_parallel_submission_completion_drains_batch_before_finalizing(
+        self,
+        config_space,
+        objectives,
+        mock_function,
+        sample_dataset,
+        monkeypatch,
+    ):
+        """Terminal completion in a parallel batch drains already-computed siblings."""
+        monkeypatch.delenv("TRAIGENT_OFFLINE", raising=False)
+        monkeypatch.delenv("TRAIGENT_OFFLINE_MODE", raising=False)
+        optimizer = MockOptimizer(config_space, objectives)
+        optimizer.set_max_suggestions(3)
+        evaluator = MockEvaluator(metrics=["accuracy"])
+
+        with patch(
+            "traigent.cloud.backend_client.BackendIntegratedClient"
+        ) as mock_backend:
+            mock_client = MagicMock()
+            mock_client.create_session.return_value = "parallel-session-complete"
+            mapping = MagicMock()
+            mapping.experiment_id = "exp_parallel_complete"
+            mapping.experiment_run_id = "run_parallel_complete"
+            mock_client.get_session_mapping.return_value = mapping
+            mock_backend.return_value = mock_client
+
+            orchestrator = OptimizationOrchestrator(
+                optimizer=optimizer,
+                evaluator=evaluator,
+                max_trials=5,
+                parallel_trials=3,
+                timeout=5.0,
+            )
+            orchestrator.backend_client = mock_client
+            orchestrator.traigent_config.execution_mode = "hybrid"
+            orchestrator.traigent_config.result_source = "cloud_brain"
+            orchestrator.traigent_config.fallback_reason = None
+            orchestrator.traigent_config.no_egress = False
+            orchestrator._submit_usage_analytics = AsyncMock()
+            orchestrator._workflow_trace_manager.submit_traces = AsyncMock()
+
+            manager = orchestrator.backend_session_manager
+            manager._backend_tracking_enabled = True
+            manager._runtime_degraded = False
+            manager._no_egress = False
+            manager.submit_trial = AsyncMock(
+                side_effect=[
+                    True,
+                    BackendTrialSubmissionOutcome.complete("converged"),
+                ]
+            )
+            manager.update_weighted_scores = AsyncMock(return_value=0)
+            manager.submit_session_aggregation = MagicMock()
+            manager.finalize_session = MagicMock(
+                return_value={"status": "completed", "metadata": {}}
+            )
+
+            result = await orchestrator.optimize(mock_function, sample_dataset)
+
+        assert result.status == OptimizationStatus.COMPLETED
+        assert result.stop_reason == "convergence"
+        assert len(result.trials) == 3
+        assert [trial.config["param1"] for trial in result.trials] == [0, 1, 2]
+        assert [trial.trial_id for trial in orchestrator._trials] == [
+            trial.trial_id for trial in result.trials
+        ]
+        assert manager.submit_trial.await_count == 2
+        submitted_param_values = [
+            call.kwargs["trial_result"].config["param1"]
+            for call in manager.submit_trial.await_args_list
+        ]
+        assert submitted_param_values == [0, 1]
+        manager.finalize_session.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_parallel_result_processing_propagates_non_terminal_exception(
+        self, orchestrator
+    ):
+        """Non-terminal processing errors still stop the batch immediately."""
+        trial_results = [
+            TrialResult(
+                trial_id=f"trial-{index}",
+                config={"param1": index},
+                metrics={"accuracy": 0.5},
+                status=TrialStatus.COMPLETED,
+                duration=0.1,
+                timestamp=datetime.now(UTC),
+            )
+            for index in range(3)
+        ]
+        permitted_results = [
+            PermittedTrialResult(
+                result=trial_result,
+                permit=Permit(id=index, amount=0.0, active=False),
+            )
+            for index, trial_result in enumerate(trial_results)
+        ]
+        handled_trial_ids: list[str] = []
+
+        async def handle_result(**kwargs):
+            handled_trial_ids.append(kwargs["trial_result"].trial_id)
+            if len(handled_trial_ids) == 2:
+                raise RuntimeError("non-terminal failure")
+            return kwargs["current_trial_index"] + 1
+
+        orchestrator._handle_trial_result = AsyncMock(side_effect=handle_result)
+
+        with pytest.raises(RuntimeError, match="non-terminal failure"):
+            await orchestrator._process_parallel_results(
+                scheduled_configs=[trial.config for trial in trial_results],
+                results=permitted_results,
+                scheduled_optuna_ids=[None, None, None],
+                session_id="session-123",
+                trial_count=0,
+            )
+
+        assert handled_trial_ids == ["trial-0", "trial-1"]
 
     @pytest.mark.asyncio
     async def test_default_config_is_evaluated_first(

--- a/tests/unit/core/test_orchestrator.py
+++ b/tests/unit/core/test_orchestrator.py
@@ -43,6 +43,7 @@ from traigent.evaluators.base import (
     EvaluationResult,
 )
 from traigent.optimizers.base import BaseOptimizer
+from traigent.optimizers.interactive_optimizer import CloudBrainOptimizationComplete
 from traigent.utils.exceptions import OptimizationError, TrialPrunedError
 from traigent.utils.file_versioning import FileVersionManager
 
@@ -99,6 +100,32 @@ class MockOptimizer(BaseOptimizer):
     def force_stop(self):
         """Force optimizer to stop."""
         self._should_stop = True
+
+
+class CloudBrainCompletingOptimizer(MockOptimizer):
+    """Async optimizer that completes normally after completed and pruned trials."""
+
+    async def suggest_next_trial_async(
+        self,
+        history: list[TrialResult],
+        remote_context: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        if len(history) == 0:
+            return {"param1": 0, "mode": "complete"}
+        if len(history) == 1:
+            return {"param1": 1, "mode": "prune"}
+        raise CloudBrainOptimizationComplete("max_trials_reached")
+
+
+class CloudBrainFailingOptimizer(MockOptimizer):
+    """Async optimizer that fails suggestion with a genuine transport error."""
+
+    async def suggest_next_trial_async(
+        self,
+        history: list[TrialResult],
+        remote_context: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        raise OptimizationError("transport failure")
 
 
 class MockEvaluator(BaseEvaluator):
@@ -176,6 +203,31 @@ class MockEvaluator(BaseEvaluator):
     def set_metrics(self, metrics: dict[str, float]):
         """Set metrics to return."""
         self.metrics_to_return = metrics
+
+
+class PruningModeEvaluator(MockEvaluator):
+    """Evaluator that prunes configs marked with mode='prune'."""
+
+    async def evaluate(
+        self,
+        func: Callable,
+        config: dict[str, Any],
+        dataset: Dataset,
+        *,
+        sample_lease=None,
+        progress_callback: Callable[[int, dict[str, Any]], Any] | None = None,
+        **kwargs,
+    ) -> EvaluationResult:
+        if config.get("mode") == "prune":
+            raise TrialPrunedError("backend pruned", step=1)
+        return await super().evaluate(
+            func,
+            config,
+            dataset,
+            sample_lease=sample_lease,
+            progress_callback=progress_callback,
+            **kwargs,
+        )
 
 
 class TestOptimizationOrchestrator:
@@ -361,6 +413,73 @@ class TestOptimizationOrchestrator:
         for trial_result in result.trials:
             assert trial_result.status == TrialStatus.COMPLETED
             assert trial_result.config is not None
+
+    @pytest.mark.asyncio
+    async def test_cloud_brain_completion_finalizes_completed_and_pruned_trials(
+        self,
+        config_space,
+        objectives,
+        mock_function,
+        sample_dataset,
+    ):
+        """Normal cloud-brain completion finalizes instead of failing suggestion."""
+        optimizer = CloudBrainCompletingOptimizer(config_space, objectives)
+        evaluator = PruningModeEvaluator()
+
+        with patch(
+            "traigent.cloud.backend_client.BackendIntegratedClient"
+        ) as mock_backend:
+            mock_client = MagicMock()
+            mock_client.create_session.return_value = "session-cloud-complete"
+            mock_backend.return_value = mock_client
+
+            orchestrator = OptimizationOrchestrator(
+                optimizer=optimizer,
+                evaluator=evaluator,
+                max_trials=10,
+                timeout=5.0,
+            )
+            orchestrator.backend_client = mock_client
+
+            result = await orchestrator.optimize(mock_function, sample_dataset)
+
+        assert result.status == OptimizationStatus.COMPLETED
+        assert result.stop_reason == "max_trials_reached"
+        assert [trial.status for trial in result.trials] == [
+            TrialStatus.COMPLETED,
+            TrialStatus.PRUNED,
+        ]
+        assert len(result.trials) == 2
+
+    @pytest.mark.asyncio
+    async def test_cloud_brain_suggestion_failure_still_raises(
+        self,
+        config_space,
+        objectives,
+        mock_function,
+        sample_dataset,
+    ):
+        """Transport or backend suggestion failures are not treated as completion."""
+        optimizer = CloudBrainFailingOptimizer(config_space, objectives)
+        evaluator = MockEvaluator()
+
+        with patch(
+            "traigent.cloud.backend_client.BackendIntegratedClient"
+        ) as mock_backend:
+            mock_client = MagicMock()
+            mock_client.create_session.return_value = "session-cloud-failure"
+            mock_backend.return_value = mock_client
+
+            orchestrator = OptimizationOrchestrator(
+                optimizer=optimizer,
+                evaluator=evaluator,
+                max_trials=10,
+                timeout=5.0,
+            )
+            orchestrator.backend_client = mock_client
+
+            with pytest.raises(OptimizationError, match="transport failure"):
+                await orchestrator.optimize(mock_function, sample_dataset)
 
     @pytest.mark.asyncio
     async def test_default_config_is_evaluated_first(

--- a/tests/unit/core/test_trial_lifecycle.py
+++ b/tests/unit/core/test_trial_lifecycle.py
@@ -175,6 +175,24 @@ class RecordingSmartPruningManager:
         return {"prune": False, "prune_reason": None}
 
 
+class LowScorePruningManager(RecordingSmartPruningManager):
+    """Prune only when the streamed running score is below the configured floor."""
+
+    def __init__(self, *, score_floor: float) -> None:
+        super().__init__(enabled=True)
+        self.score_floor = score_floor
+
+    def report_intermediate_progress(self, payload: dict[str, object]):
+        self.reports.append(dict(payload))
+        running_score = float(payload.get("running_score") or 0.0)
+        if running_score < self.score_floor:
+            return {
+                "prune": True,
+                "prune_reason": "optimistic ceiling below best",
+            }
+        return {"prune": False, "prune_reason": None}
+
+
 class RaisingIntermediateReportClient:
     """Backend client test double whose intermediate report POST fails."""
 
@@ -494,6 +512,50 @@ class TestCreateProgressTracking:
         assert "secret prompt" not in reports_text
         assert "correct-" not in reports_text
         assert "wrong-b" not in reports_text
+
+    @pytest.mark.asyncio
+    async def test_cloud_smart_pruning_metric_function_good_config_not_pruned(self):
+        """Detailed progress streams custom objective metrics despite empty expected."""
+        orchestrator = MockOrchestrator()
+
+        def metric(output: dict[str, float], expected: dict[str, object]) -> float:
+            assert expected == {}
+            return float(output["score"])
+
+        orchestrator.evaluator = LocalEvaluator(
+            metrics=["accuracy"],
+            detailed=True,
+            metric_functions={"accuracy": metric},
+        )
+        manager = LowScorePruningManager(score_floor=50.0)
+        orchestrator.backend_session_manager = manager
+        lifecycle = TrialLifecycle(orchestrator)
+        dataset = Dataset(
+            examples=[
+                EvaluationExample({"score": 90.0}, {}),
+                EvaluationExample({"score": 95.0}, {}),
+            ],
+            name="smart-pruning-custom-metric",
+        )
+
+        def answer(score: float) -> dict[str, float]:
+            return {"score": score}
+
+        result = await lifecycle.run_trial(
+            func=answer,
+            config={"temperature": 0.2},
+            dataset=dataset,
+            trial_number=1,
+            session_id="session-123",
+        )
+
+        assert result.status == TrialStatus.COMPLETED
+        assert result.metrics["accuracy"] == pytest.approx(92.5)
+        assert manager.reports
+        assert manager.reports[0]["running_score"] == pytest.approx(90.0)
+        assert manager.reports[1]["running_score"] == pytest.approx(92.5)
+        assert all(float(report["running_score"]) >= 50.0 for report in manager.reports)
+        assert "output" not in str(manager.reports)
 
     @pytest.mark.asyncio
     async def test_cloud_smart_pruning_report_failure_continues_trial(

--- a/tests/unit/core/test_trial_lifecycle.py
+++ b/tests/unit/core/test_trial_lifecycle.py
@@ -446,6 +446,33 @@ class TestCreateProgressTracking:
         assert "output" not in manager.reports[0]
 
     @pytest.mark.asyncio
+    async def test_pruned_cloud_trial_marks_backend_id_acquired(self):
+        """A pruned cloud trial reuses its already-minted backend trial id."""
+        orchestrator = MockOrchestrator()
+        orchestrator.evaluator = SmartPruningEvaluator()
+        manager = RecordingSmartPruningManager(prune_after=1)
+        orchestrator.backend_session_manager = manager
+        lifecycle = TrialLifecycle(orchestrator)
+        dataset = create_real_dataset(size=2)
+
+        result = await lifecycle.run_trial(
+            func=lambda value: value,
+            config={
+                "temperature": 0.2,
+                "_traigent_backend_trial_id": "be-pruned-123",
+            },
+            dataset=dataset,
+            trial_number=1,
+            session_id="session-123",
+        )
+
+        assert result.status == TrialStatus.PRUNED
+        assert result.trial_id == "be-pruned-123"
+        assert result.metadata["backend_trial_id_acquired"] is True
+        assert result.metadata["backend_trial_id_source"] == "cloud_brain"
+        assert manager.reports[0]["trial_id"] == "be-pruned-123"
+
+    @pytest.mark.asyncio
     async def test_cloud_smart_pruning_uses_real_per_example_accuracy(self):
         """Real evaluator progress reports true partial accuracy, not success rate."""
         orchestrator = MockOrchestrator()

--- a/tests/unit/evaluators/test_detailed_progress_metric_functions.py
+++ b/tests/unit/evaluators/test_detailed_progress_metric_functions.py
@@ -1,0 +1,107 @@
+"""Regression tests for detailed progress payload objective metrics."""
+
+from __future__ import annotations
+
+import pytest
+
+from traigent.api.types import ExampleResult
+from traigent.core.trial_lifecycle import TrialLifecycle
+from traigent.evaluators.base import Dataset, EvaluationExample
+from traigent.evaluators.local import LocalEvaluator
+
+
+def test_detailed_progress_payload_uses_metric_function_with_empty_expected_output():
+    calls: list[tuple[dict[str, float], dict[str, object], dict[str, float]]] = []
+
+    def metric(
+        output: dict[str, float],
+        expected: dict[str, object],
+        metrics: dict[str, float],
+    ) -> float:
+        calls.append((output, expected, metrics))
+        return float(output["acc"])
+
+    evaluator = LocalEvaluator(
+        metrics=["accuracy"],
+        detailed=True,
+        metric_functions={"accuracy": metric},
+    )
+    dataset = Dataset(
+        examples=[
+            EvaluationExample(input_data={"row": 0}, expected_output={}),
+            EvaluationExample(input_data={"row": 1}, expected_output={}),
+        ],
+        name="empty-expected-custom-metric",
+    )
+    result = ExampleResult(
+        example_id="example_0",
+        input_data=dataset.examples[0].input_data,
+        expected_output=dataset.examples[0].expected_output,
+        actual_output={"acc": 75.0},
+        metrics={"total_tokens": 12.0},
+        execution_time=0.01,
+        success=True,
+        error_message=None,
+        metadata={},
+    )
+
+    payload = evaluator._build_progress_payload(
+        "example_0",
+        dataset.examples[0],
+        result,
+        {"level": 9},
+        None,
+        dataset,
+        0,
+    )
+
+    assert payload["metrics"]["accuracy"] == pytest.approx(75.0)
+    assert calls == [({"acc": 75.0}, {}, {"total_tokens": 12.0})]
+
+
+@pytest.mark.asyncio
+async def test_detailed_progress_running_score_uses_raw_metric_scale():
+    def metric(output: dict[str, float], expected: dict[str, object]) -> float:
+        assert expected == {}
+        return float(output["acc"])
+
+    evaluator = LocalEvaluator(
+        metrics=["accuracy"],
+        detailed=True,
+        metric_functions={"accuracy": metric},
+    )
+    dataset = Dataset(
+        examples=[
+            EvaluationExample(input_data={"acc": 75.0}, expected_output={}),
+            EvaluationExample(input_data={"acc": 95.0}, expected_output={}),
+        ],
+        name="raw-scale-custom-metric",
+    )
+    reports: list[tuple[int, dict[str, object]]] = []
+
+    def capture(index: int, payload: dict[str, object]) -> None:
+        if "metrics" in payload:
+            reports.append((index, payload))
+
+    def emit(acc: float) -> dict[str, float]:
+        return {"acc": acc}
+
+    result = await evaluator.evaluate(
+        emit,
+        {},
+        dataset,
+        progress_callback=capture,
+    )
+
+    detailed_reports = reports[: len(dataset.examples)]
+    streamed_values = [
+        TrialLifecycle._extract_progress_value(
+            dict(payload),  # classmethod treats the payload as read-only
+            "accuracy",
+        )
+        for _, payload in detailed_reports
+    ]
+
+    assert streamed_values == [75.0, 95.0]
+    assert sum(streamed_values) / len(streamed_values) == pytest.approx(85.0)
+    assert result.metrics["accuracy"] == pytest.approx(85.0)

--- a/tests/unit/optimizers/test_interactive_optimizer.py
+++ b/tests/unit/optimizers/test_interactive_optimizer.py
@@ -16,6 +16,7 @@ from traigent.cloud.models import (
     TrialSuggestion,
 )
 from traigent.optimizers.interactive_optimizer import (
+    CloudBrainOptimizationComplete,
     InteractiveOptimizer,
     RemoteGuidanceService,
 )
@@ -158,6 +159,56 @@ class TestInteractiveOptimizer:
 
         assert result is None
         assert optimizer.session.status == OptimizationSessionStatus.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_suggest_next_trial_async_completion_raises_cloud_complete(
+        self, optimizer, mock_remote_service
+    ):
+        """should_continue=False without a suggestion is normal cloud completion."""
+        mock_remote_service.create_session.return_value = SessionCreationResponse(
+            session_id="session-123",
+            status=OptimizationSessionStatus.ACTIVE,
+            optimization_strategy={},
+        )
+        await optimizer.initialize_session("test_function", 50)
+
+        mock_remote_service.get_next_trial.return_value = NextTrialResponse(
+            suggestion=None,
+            should_continue=False,
+            reason="fallback reason",
+            stop_reason="max_trials_reached",
+            session_status=OptimizationSessionStatus.COMPLETED,
+        )
+
+        with pytest.raises(CloudBrainOptimizationComplete) as exc_info:
+            await optimizer.suggest_next_trial_async(history=[])
+
+        assert exc_info.value.reason == "max_trials_reached"
+        assert optimizer.session.status == OptimizationSessionStatus.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_suggest_next_trial_async_errors_when_continuing_without_suggestion(
+        self, optimizer, mock_remote_service
+    ):
+        """should_continue=True without a suggestion is a backend contract error."""
+        mock_remote_service.create_session.return_value = SessionCreationResponse(
+            session_id="session-123",
+            status=OptimizationSessionStatus.ACTIVE,
+            optimization_strategy={},
+        )
+        await optimizer.initialize_session("test_function", 50)
+
+        mock_remote_service.get_next_trial.return_value = NextTrialResponse(
+            suggestion=None,
+            should_continue=True,
+            session_status=OptimizationSessionStatus.ACTIVE,
+        )
+
+        with pytest.raises(
+            OptimizationError,
+            match="Cloud brain returned no suggestion while should_continue=True",
+        ):
+            await optimizer.suggest_next_trial_async(history=[])
 
     @pytest.mark.asyncio
     async def test_report_results(self, optimizer, mock_remote_service):

--- a/traigent/cloud/backend_client.py
+++ b/traigent/cloud/backend_client.py
@@ -64,7 +64,7 @@ from traigent.cloud.privacy_operations import PrivacyOperations
 from traigent.cloud.session_operations import SessionOperations
 from traigent.cloud.session_types import SessionCreationResult
 from traigent.cloud.subset_selection import SmartSubsetSelector
-from traigent.cloud.trial_operations import TrialOperations
+from traigent.cloud.trial_operations import TrialOperations, TrialSlotResult
 from traigent.cloud.url_security import (
     CloudUrlUnreachableError,
     validate_cloud_base_url,
@@ -1879,16 +1879,15 @@ class BackendIntegratedClient:
             self._trial_ops.register_trial_start_sync(session_id, trial_id, config),
         )
 
-    async def request_trial_slot(self, session_id: str) -> str | None:
+    async def request_trial_slot(self, session_id: str) -> TrialSlotResult:
         """Acquire a backend-minted trial id (configuration_run) for a session.
         Delegates to trial_operations module.
 
         Returns:
-            The backend-minted trial id, or ``None`` when no slot could be
-            acquired (offline / transport unavailable / non-2xx / backend
-            declined). ``None`` never means "use a client id".
+            A neutral slot result: acquired backend trial id, explicit
+            optimization-complete signal, or unavailable/error.
         """
-        return cast(str | None, await self._trial_ops.request_trial_slot(session_id))
+        return await self._trial_ops.request_trial_slot(session_id)
 
     def _generate_trial_id(
         self,

--- a/traigent/cloud/trial_operations.py
+++ b/traigent/cloud/trial_operations.py
@@ -11,6 +11,7 @@ import concurrent.futures
 import hashlib
 import json
 import re
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -40,6 +41,30 @@ if TYPE_CHECKING:
     from traigent.cloud.backend_client import BackendIntegratedClient
 
 logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class TrialSlotResult:
+    """Neutral result for a backend trial-slot request."""
+
+    trial_id: str | None = None
+    optimization_complete: bool = False
+    reason: str | None = None
+
+    def __bool__(self) -> bool:
+        return bool(self.trial_id)
+
+    @classmethod
+    def acquired(cls, trial_id: str) -> "TrialSlotResult":
+        return cls(trial_id=trial_id)
+
+    @classmethod
+    def complete(cls, reason: str | None = None) -> "TrialSlotResult":
+        return cls(optimization_complete=True, reason=reason)
+
+    @classmethod
+    def unavailable(cls) -> "TrialSlotResult":
+        return cls()
 
 
 class TrialOperations:
@@ -380,7 +405,7 @@ class TrialOperations:
     async def request_trial_slot(
         self,
         session_id: str,
-    ) -> str | None:
+    ) -> TrialSlotResult:
         """Acquire a BACKEND-minted trial id (configuration_run) for a session.
 
         The backend mints configuration_run ids only through its
@@ -392,25 +417,26 @@ class TrialOperations:
         and the backend's own suggested config is irrelevant to the SDK.
 
         Returns:
-            The backend-minted trial id, or ``None`` when no slot could be
-            acquired (offline mode, transport unavailable, non-2xx, or the
-            backend declined to suggest a further trial). ``None`` NEVER means
-            "use a client id" — callers fail closed on it (Rule 2: no fake
-            trial acknowledgment).
+            A neutral slot result. ``trial_id`` means a backend-minted slot was
+            acquired. ``optimization_complete`` means a successful next-trial
+            response explicitly returned ``should_continue=False`` without a
+            trial id. Any other no-slot/error condition returns an unavailable
+            result; callers still fail closed on it (Rule 2: no fake trial
+            acknowledgment).
         """
-        # Skip backend calls in offline mode — None lets callers distinguish
-        # "skipped" from "acquired" (Rule 2: no fake completion).
+        # Skip backend calls in offline mode — an unavailable result lets
+        # callers distinguish "skipped" from "acquired" (Rule 2: no fake completion).
         if is_backend_offline():
             logger.debug(
                 "Offline mode: skipping trial-slot request for session %s",
                 session_id,
             )
-            return None
+            return TrialSlotResult.unavailable()
         self._raise_if_backend_egress_disabled("get next trial")
 
         if not AIOHTTP_AVAILABLE:
             logger.warning("aiohttp not available, skipping trial-slot request")
-            return None
+            return TrialSlotResult.unavailable()
 
         try:
             headers = await self.client.auth_manager.augment_headers(
@@ -446,7 +472,21 @@ class TrialOperations:
                                 trial_id,
                                 session_id,
                             )
-                            return trial_id
+                            return TrialSlotResult.acquired(trial_id)
+                        if (
+                            isinstance(data, dict)
+                            and data.get("should_continue") is False
+                        ):
+                            reason = data.get("stop_reason") or data.get("reason")
+                            logger.info(
+                                "Backend next-trial completed optimization for session %s "
+                                "(reason=%s)",
+                                session_id,
+                                reason,
+                            )
+                            return TrialSlotResult.complete(
+                                str(reason) if reason else None
+                            )
                         logger.info(
                             "Backend next-trial returned no slot for session %s "
                             "(should_continue=%s)",
@@ -457,7 +497,7 @@ class TrialOperations:
                                 else None
                             ),
                         )
-                        return None
+                        return TrialSlotResult.unavailable()
                     if response.status == 403:
                         error_msg = await response.text()
                         self._log_ownership_forbidden(
@@ -466,26 +506,26 @@ class TrialOperations:
                             response.status,
                             error_msg,
                         )
-                        return None
+                        return TrialSlotResult.unavailable()
                     logger.warning(
                         "Failed to acquire trial slot for session %s: HTTP %s",
                         session_id,
                         response.status,
                     )
-                    return None
+                    return TrialSlotResult.unavailable()
         except Exception as exc:
             if is_backend_offline():
                 logger.debug(
                     "Offline mode: trial-slot request encountered %s; skipping",
                     exc,
                 )
-                return None
+                return TrialSlotResult.unavailable()
             logger.exception(
                 "Error requesting trial slot for session %s (%s)",
                 session_id,
                 self._describe_backend(),
             )
-            return None
+            return TrialSlotResult.unavailable()
 
     def _extract_measures_from_metrics(
         self, metrics: dict[str, Any]

--- a/traigent/core/backend_session_manager.py
+++ b/traigent/core/backend_session_manager.py
@@ -8,6 +8,7 @@ import asyncio
 import inspect
 import threading
 from collections.abc import Callable, Coroutine
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
 from traigent._version import get_version
@@ -131,6 +132,27 @@ def _backend_disabled_label(reason: SessionCreationFailureReason | None) -> str:
     if reason == SessionCreationFailureReason.SESSION_FAILED:
         return "session-create-failed"
     return "unknown"
+
+
+@dataclass(frozen=True)
+class BackendTrialSlotAcquisition:
+    """Core-local interpretation of a backend trial-slot request."""
+
+    trial_id: str | None = None
+    optimization_complete: bool = False
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class BackendTrialSubmissionOutcome:
+    """Terminal submission outcome consumed by the orchestrator."""
+
+    optimization_complete: bool = False
+    reason: str | None = None
+
+    @classmethod
+    def complete(cls, reason: str | None = None) -> BackendTrialSubmissionOutcome:
+        return cls(optimization_complete=True, reason=reason)
 
 
 def _format_untracked_warning_block(
@@ -940,7 +962,7 @@ class BackendSessionManager:
         session_id: str | None,
         dataset_name: str = "dataset",
         content_scores: dict[str, dict[int, float]] | None = None,
-    ) -> bool:
+    ) -> bool | BackendTrialSubmissionOutcome:
         """Submit trial to backend.
 
         Args:
@@ -951,7 +973,9 @@ class BackendSessionManager:
                 per-run features once at session creation.
 
         Returns:
-            True if submission succeeded
+            True if submission succeeded, False if skipped, or a terminal
+            optimization-complete outcome when the backend gracefully closed the
+            cloud run.
         """
         if self._egress_disabled() or not self._backend_client or not session_id:
             return False
@@ -990,12 +1014,14 @@ class BackendSessionManager:
             )
             return False
 
-        await self._log_trial_to_backend(
+        submission_outcome = await self._log_trial_to_backend(
             session_id=session_id,
             trial_result=trial_result,
             score=score,
             metadata=trial_metadata,
         )
+        if submission_outcome is not None and submission_outcome.optimization_complete:
+            return submission_outcome
 
         return True
 
@@ -1045,36 +1071,53 @@ class BackendSessionManager:
         """
         return (session_id, trial_id) in self._acknowledged_trials
 
+    @staticmethod
+    def _coerce_backend_trial_slot(slot: Any) -> BackendTrialSlotAcquisition:
+        """Normalize legacy string/None and structured slot results."""
+
+        if isinstance(slot, str) and slot:
+            return BackendTrialSlotAcquisition(trial_id=slot)
+        if getattr(slot, "optimization_complete", False) is True:
+            reason = getattr(slot, "reason", None)
+            return BackendTrialSlotAcquisition(
+                optimization_complete=True,
+                reason=str(reason) if reason else None,
+            )
+        trial_id = getattr(slot, "trial_id", None)
+        if isinstance(trial_id, str) and trial_id:
+            return BackendTrialSlotAcquisition(trial_id=trial_id)
+        return BackendTrialSlotAcquisition()
+
     async def _acquire_backend_trial_id(
         self, session_id: str, trial_result: TrialResult
-    ) -> str | None:
+    ) -> BackendTrialSlotAcquisition:
         """Acquire (once per started trial) a backend-minted trial id.
 
         Reuses a previously acquired backend id for the same client trial so
-        retries of submit_trial don't burn extra slots. Returns ``None`` when
-        the backend declined to mint a slot (offline / transport / non-2xx),
-        in which case the caller fails closed.
+        retries of submit_trial don't burn extra slots. Returns a structured
+        outcome so graceful backend completion is not collapsed into the genuine
+        no-slot/error path.
         """
         client = self._backend_client
         if self._egress_disabled() or client is None:
-            return None
+            return BackendTrialSlotAcquisition()
 
         client_trial_id = str(trial_result.trial_id)
         if (trial_result.metadata or {}).get("backend_trial_id_acquired"):
             self._started_trials.add((session_id, client_trial_id))
-            return client_trial_id
+            return BackendTrialSlotAcquisition(trial_id=client_trial_id)
         # If this trial already mapped to an acknowledged backend id, reuse it.
         for sid, bid in self._started_trials:
             if sid == session_id and bid == client_trial_id:
                 # client_trial_id already IS a backend id from a prior pass.
-                return client_trial_id
+                return BackendTrialSlotAcquisition(trial_id=client_trial_id)
 
         requester = getattr(client, "request_trial_slot", None)
         if not callable(requester):
-            return None
+            return BackendTrialSlotAcquisition()
         try:
             slot = requester(session_id)
-            backend_trial_id = await slot if inspect.isawaitable(slot) else slot
+            slot_result = await slot if inspect.isawaitable(slot) else slot
         except Exception as exc:
             logger.debug(
                 "Backend trial-slot request failed for session %s trial %s: %s",
@@ -1082,12 +1125,12 @@ class BackendSessionManager:
                 client_trial_id,
                 exc,
             )
-            return None
+            return BackendTrialSlotAcquisition()
 
-        if isinstance(backend_trial_id, str) and backend_trial_id:
-            self._started_trials.add((session_id, backend_trial_id))
-            return backend_trial_id
-        return None
+        acquisition = self._coerce_backend_trial_slot(slot_result)
+        if acquisition.trial_id:
+            self._started_trials.add((session_id, acquisition.trial_id))
+        return acquisition
 
     async def _log_trial_to_backend(
         self,
@@ -1095,14 +1138,14 @@ class BackendSessionManager:
         trial_result: TrialResult,
         score: float | None,
         metadata: dict[str, Any],
-    ) -> None:
+    ) -> BackendTrialSubmissionOutcome | None:
         """Submit trial metrics to backend when possible."""
 
         if self._egress_disabled() or not self._backend_client or not session_id:
-            return
+            return None
 
         if not self._backend_tracking_enabled:
-            return
+            return None
 
         sanitized_score = float(score) if score is not None else None
         metadata_payload = dict(metadata)
@@ -1122,7 +1165,7 @@ class BackendSessionManager:
                 session_id,
                 trial_result.trial_id,
             )
-            return
+            return None
 
         logger.debug(
             "Submitting trial %s for session %s",
@@ -1151,7 +1194,7 @@ class BackendSessionManager:
                 session_id,
                 trial_result.trial_id,
             )
-            return
+            return None
 
         # Build payload for backend session endpoint.
         metrics_payload: dict[str, Any] = dict(trial_result.metrics or {})
@@ -1194,9 +1237,17 @@ class BackendSessionManager:
             # "Trial ... not found in session". So acquire a backend slot and
             # rebind this trial to it BEFORE submitting. The optimizer still
             # owns the config; the slot is purely the backend's trial handle.
-            backend_trial_id = await self._acquire_backend_trial_id(
-                session_id, trial_result
-            )
+            acquisition = await self._acquire_backend_trial_id(session_id, trial_result)
+            if acquisition.optimization_complete:
+                logger.info(
+                    "Backend reported optimization complete for session %s while "
+                    "submitting client trial %s (reason=%s)",
+                    session_id,
+                    trial_result.trial_id,
+                    acquisition.reason,
+                )
+                return BackendTrialSubmissionOutcome.complete(acquisition.reason)
+            backend_trial_id = acquisition.trial_id
             if backend_trial_id is None:
                 # Fail closed: no acknowledged backend slot ⇒ NO submission and
                 # NO acknowledgment. The certified-selection report will then
@@ -1210,7 +1261,7 @@ class BackendSessionManager:
                     session_id,
                     trial_result.trial_id,
                 )
-                return
+                return None
             # Rebind in place: _best_trial_cached holds this same object, so the
             # incumbent's trial_id becomes the backend id the report needs.
             trial_result.trial_id = backend_trial_id

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -1444,13 +1444,14 @@ class OptimizationOrchestrator:
             # on _consumed_examples during parallel trial execution
             self._register_examples_attempted(trial_result)
 
+        submission_outcome: Any = None
         if self.backend_client and session_id:
             pre_submit_trial_id = (
                 str(trial_result.trial_id)
                 if getattr(trial_result, "trial_id", None) is not None
                 else None
             )
-            await self.backend_session_manager.submit_trial(
+            submission_outcome = await self.backend_session_manager.submit_trial(
                 trial_result=trial_result,
                 session_id=session_id,
                 dataset_name=getattr(self, "_dataset_name", "dataset"),
@@ -1487,6 +1488,12 @@ class OptimizationOrchestrator:
 
         if should_log:
             self._log_progress(new_count)
+
+        if getattr(submission_outcome, "optimization_complete", False) is True:
+            reason = getattr(submission_outcome, "reason", None)
+            raise CloudBrainOptimizationComplete(
+                str(reason) if reason else "cloud brain completed optimization"
+            )
 
         return new_count
 
@@ -2592,7 +2599,7 @@ class OptimizationOrchestrator:
         except CloudBrainOptimizationComplete as complete:
             self._stop_reason = cast(StopReason, complete.stop_reason)
             logger.info("Cloud brain completed optimization: %s", complete.reason)
-            return trial_count, "break"
+            return len(self._trials), "break"
 
     @staticmethod
     def _vendor_retry_settings() -> tuple[int, float]:

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -1379,6 +1379,7 @@ class OptimizationOrchestrator:
         *,
         log_on_success: bool,
         permit: Permit | None = None,
+        submit_to_backend: bool = True,
     ) -> int:
         """Update orchestrator state after a single trial completes.
 
@@ -1445,7 +1446,7 @@ class OptimizationOrchestrator:
             self._register_examples_attempted(trial_result)
 
         submission_outcome: Any = None
-        if self.backend_client and session_id:
+        if submit_to_backend and self.backend_client and session_id:
             pre_submit_trial_id = (
                 str(trial_result.trial_id)
                 if getattr(trial_result, "trial_id", None) is not None
@@ -1846,6 +1847,9 @@ class OptimizationOrchestrator:
         - Exceptions (due to return_exceptions=True in gather)
         - None for trials cancelled due to cost limit
         """
+        terminal_completion: CloudBrainOptimizationComplete | None = None
+        submit_to_backend = True
+
         for batch_offset, (config, permitted_result, optuna_id) in enumerate(
             zip(scheduled_configs, results, scheduled_optuna_ids, strict=False)
         ):
@@ -1903,7 +1907,13 @@ class OptimizationOrchestrator:
                     optuna_trial_id=optuna_id,
                     log_on_success=False,
                     permit=permit,
+                    submit_to_backend=submit_to_backend,
                 )
+            except CloudBrainOptimizationComplete as complete:
+                if terminal_completion is None:
+                    terminal_completion = complete
+                submit_to_backend = False
+                trial_count = len(self._trials)
             except Exception:
                 # Release permit on any exception to prevent stranding
                 # (only if permit is still active - wasn't already released)
@@ -1914,6 +1924,8 @@ class OptimizationOrchestrator:
                         permit.id,
                     )
                 raise
+        if terminal_completion is not None:
+            raise terminal_completion
         return trial_count
 
     def _apply_cap_and_prevent_excess(

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -101,6 +101,7 @@ from traigent.core.workflow_trace_manager import WorkflowTraceManager
 from traigent.evaluators.base import BaseEvaluator, Dataset
 from traigent.metrics.registry import clone_registry
 from traigent.optimizers.base import BaseOptimizer
+from traigent.optimizers.interactive_optimizer import CloudBrainOptimizationComplete
 from traigent.tvl.promotion_gate import PromotionGate
 from traigent.utils.callbacks import CallbackManager, OptimizationCallback, ProgressInfo
 from traigent.utils.env_config import (  # noqa: F401
@@ -2588,6 +2589,10 @@ class OptimizationOrchestrator:
                 self._stop_reason = "vendor_error"
                 return trial_count, "break"
             return trial_count, "continue"  # User chose to resume
+        except CloudBrainOptimizationComplete as complete:
+            self._stop_reason = cast(StopReason, complete.stop_reason)
+            logger.info("Cloud brain completed optimization: %s", complete.reason)
+            return trial_count, "break"
 
     @staticmethod
     def _vendor_retry_settings() -> tuple[int, float]:

--- a/traigent/core/trial_lifecycle.py
+++ b/traigent/core/trial_lifecycle.py
@@ -431,11 +431,7 @@ class TrialLifecycle:
                     lambda: frozenset(),
                 )(),
             )
-            if isinstance(backend_trial_id, str) and backend_trial_id:
-                metadata = dict(result.metadata or {})
-                metadata["backend_trial_id_acquired"] = True
-                metadata["backend_trial_id_source"] = "cloud_brain"
-                result.metadata = metadata
+            self._mark_backend_trial_id_acquired(result, backend_trial_id)
             self._apply_budget_metadata(result, closure, budget_exhausted)
             self._apply_effectuation_metadata(result, func)
 
@@ -463,6 +459,7 @@ class TrialLifecycle:
                 prune_error,
                 is_pruned=True,
             )
+            self._mark_backend_trial_id_acquired(result, backend_trial_id)
             self._apply_effectuation_metadata(result, func)
             record_trial_result(span, status="pruned", error=str(prune_error))
             end_time = time.time()
@@ -479,6 +476,7 @@ class TrialLifecycle:
                 optuna_trial_id,
                 constraint_error,
             )
+            self._mark_backend_trial_id_acquired(result, backend_trial_id)
             self._apply_effectuation_metadata(result, func)
             record_trial_result(span, status="failed", error=str(constraint_error))
             end_time = time.time()
@@ -523,6 +521,7 @@ class TrialLifecycle:
                 optuna_trial_id,
                 exc,
             )
+            self._mark_backend_trial_id_acquired(result, backend_trial_id)
             self._apply_effectuation_metadata(result, func)
             record_trial_result(span, status="failed", error=str(exc))
             end_time = time.time()
@@ -532,6 +531,18 @@ class TrialLifecycle:
         finally:
             if lease is not None and closure is None:
                 closure = self._finalize_budget_lease(lease)
+
+    @staticmethod
+    def _mark_backend_trial_id_acquired(
+        result: TrialResult,
+        backend_trial_id: str | None,
+    ) -> None:
+        if not isinstance(backend_trial_id, str) or not backend_trial_id:
+            return
+        metadata = dict(result.metadata or {})
+        metadata["backend_trial_id_acquired"] = True
+        metadata["backend_trial_id_source"] = "cloud_brain"
+        result.metadata = metadata
 
     def _apply_effectuation_metadata(
         self,

--- a/traigent/evaluators/base.py
+++ b/traigent/evaluators/base.py
@@ -1646,6 +1646,7 @@ class BaseEvaluator(ABC):
                         config,
                         example,
                         i,
+                        dataset,
                         executor=None,
                         progress_callback=progress_callback,
                     )
@@ -2009,6 +2010,7 @@ class BaseEvaluator(ABC):
             consumed, exhausted = await self._run_concurrent_tasks(
                 func,
                 config,
+                dataset,
                 examples,
                 sample_lease,
                 detailed,
@@ -2043,6 +2045,7 @@ class BaseEvaluator(ABC):
         self,
         func: Callable[..., Any],
         config: dict[str, Any],
+        dataset: Dataset,
         examples: list[EvaluationExample],
         sample_lease: SampleBudgetLease | None,
         detailed: bool,
@@ -2066,6 +2069,7 @@ class BaseEvaluator(ABC):
                         config,
                         example,
                         idx,
+                        dataset,
                         executor=None,
                         progress_callback=progress_callback,
                     )
@@ -2238,18 +2242,31 @@ class BaseEvaluator(ABC):
         result: ExampleResult,
         config: dict[str, Any],
         error: str | None,
+        dataset: Dataset,
+        example_index: int,
     ) -> dict[str, Any]:
         """Build progress callback payload with metrics."""
-        metrics_payload = self._build_progress_accuracy_metrics(
-            output=result.actual_output,
-            expected_output=example.expected_output,
-            error=error,
-            example_id=example_id,
-        )
-
         metrics_update, _ = self._extract_response_metrics(
             example_id, example, result, config
         )
+        llm_metrics = dict(result.metrics or metrics_update)
+
+        metrics_payload = self._build_progress_objective_metrics(
+            example=example,
+            result=result,
+            config=config,
+            error=error,
+            dataset=dataset,
+            example_index=example_index,
+            llm_metrics=llm_metrics or None,
+        )
+        if not metrics_payload and not self._has_configured_progress_objective():
+            metrics_payload = self._build_progress_accuracy_metrics(
+                output=result.actual_output,
+                expected_output=example.expected_output,
+                error=error,
+                example_id=example_id,
+            )
         metrics_payload.update(metrics_update)
 
         payload: dict[str, Any] = {
@@ -2260,6 +2277,157 @@ class BaseEvaluator(ABC):
         if metrics_payload:
             payload["metrics"] = metrics_payload
         return payload
+
+    def _has_configured_progress_objective(self) -> bool:
+        """Return True when callers configured a custom per-example objective."""
+        return bool(
+            getattr(self, "metric_functions", None)
+            or getattr(self, "scoring_function", None)
+        )
+
+    def _build_progress_objective_metrics(
+        self,
+        *,
+        example: EvaluationExample,
+        result: ExampleResult,
+        config: dict[str, Any],
+        error: str | None,
+        dataset: Dataset,
+        example_index: int,
+        llm_metrics: dict[str, Any] | None,
+    ) -> dict[str, float]:
+        """Return configured per-example objective metrics for detailed progress."""
+        if error is not None:
+            return {}
+
+        metric_functions = getattr(self, "metric_functions", None) or {}
+        if metric_functions:
+            metrics = self._call_progress_metric_functions(
+                metric_functions=metric_functions,
+                output=result.actual_output,
+                example=example,
+                config=config,
+                dataset=dataset,
+                example_index=example_index,
+                llm_metrics=llm_metrics,
+            )
+            if metrics:
+                return metrics
+
+        scoring_function = getattr(self, "scoring_function", None)
+        if scoring_function is not None:
+            metrics = self._call_progress_scoring_function(
+                output=result.actual_output,
+                example=example,
+                config=config,
+                dataset=dataset,
+                example_index=example_index,
+                llm_metrics=llm_metrics,
+            )
+            if metrics:
+                return metrics
+
+        return {}
+
+    def _call_progress_metric_functions(
+        self,
+        *,
+        metric_functions: Mapping[str, Callable[..., Any]],
+        output: Any,
+        example: EvaluationExample,
+        config: dict[str, Any],
+        dataset: Dataset,
+        example_index: int,
+        llm_metrics: dict[str, Any] | None,
+    ) -> dict[str, float]:
+        """Call configured metric functions using the evaluator's scoring helper."""
+        call_metric_functions = getattr(self, "_call_metric_functions", None)
+        if callable(call_metric_functions):
+            return self._coerce_progress_metrics(
+                call_metric_functions(
+                    output, example, config, dataset, example_index, llm_metrics
+                )
+            )
+
+        invoke_metric = getattr(self, "_invoke_metric_function", None)
+        if callable(invoke_metric):
+            metrics: dict[str, float] = {}
+            for metric_name, metric_func in metric_functions.items():
+                value = invoke_metric(
+                    metric_func,
+                    metric_name,
+                    output,
+                    example,
+                    config,
+                    llm_metrics or {},
+                    example_index,
+                )
+                if isinstance(value, Mapping):
+                    metrics.update(self._coerce_progress_metrics(value))
+                elif value is not None:
+                    try:
+                        metrics[metric_name] = float(value)
+                    except (TypeError, ValueError):
+                        logger.warning(
+                            "Metric function %s returned non-numeric progress value "
+                            "for example %s",
+                            metric_name,
+                            getattr(example, "example_id", None) or example_index,
+                        )
+            return metrics
+
+        return {}
+
+    def _call_progress_scoring_function(
+        self,
+        *,
+        output: Any,
+        example: EvaluationExample,
+        config: dict[str, Any],
+        dataset: Dataset,
+        example_index: int,
+        llm_metrics: dict[str, Any] | None,
+    ) -> dict[str, float]:
+        """Call configured scoring function using the evaluator's scoring helper."""
+        compute_example_metrics = getattr(self, "_compute_example_metrics", None)
+        if callable(compute_example_metrics):
+            try:
+                return self._coerce_progress_metrics(
+                    compute_example_metrics(
+                        output, example, config, dataset, example_index, llm_metrics
+                    )
+                )
+            except TypeError:
+                logger.debug(
+                    "Evaluator _compute_example_metrics signature does not support "
+                    "detailed progress scoring; trying scoring helper",
+                    exc_info=True,
+                )
+
+        call_scoring_function = getattr(self, "_call_scoring_function", None)
+        if callable(call_scoring_function):
+            return self._coerce_progress_metrics(
+                call_scoring_function(output, example, llm_metrics)
+            )
+
+        return {}
+
+    @staticmethod
+    def _coerce_progress_metrics(values: Mapping[str, Any] | None) -> dict[str, float]:
+        """Keep only finite numeric metrics for the progress payload."""
+        metrics: dict[str, float] = {}
+        if not values:
+            return metrics
+        for name, value in values.items():
+            if isinstance(value, bool) or value is None:
+                continue
+            try:
+                number = float(value)
+            except (TypeError, ValueError):
+                continue
+            if math.isfinite(number):
+                metrics[str(name)] = number
+        return metrics
 
     def _build_progress_accuracy_metrics(
         self,
@@ -2435,6 +2603,7 @@ class BaseEvaluator(ABC):
         config: dict[str, Any],
         example: EvaluationExample,
         example_index: int,
+        dataset: Dataset,
         executor: Any | None = None,
         progress_callback: Callable[[int, dict[str, Any]], Any] | None = None,
     ) -> ExampleResult:
@@ -2501,7 +2670,7 @@ class BaseEvaluator(ABC):
 
             if progress_callback:
                 progress_payload = self._build_progress_payload(
-                    example_id, example, result, config, error
+                    example_id, example, result, config, error, dataset, example_index
                 )
                 try:
                     progress_callback(example_index, progress_payload)

--- a/traigent/optimizers/interactive_optimizer.py
+++ b/traigent/optimizers/interactive_optimizer.py
@@ -289,46 +289,52 @@ class InteractiveOptimizer(BaseOptimizer):
         if not self.session_id:
             raise OptimizationError("No active session. Call initialize_session first.")
 
+        request = NextTrialRequest(
+            session_id=self.session_id,
+            previous_results=previous_results or self._completed_trials[-5:],
+            request_metadata={
+                "dataset_size": dataset_size,
+                "completed_trials": len(self._completed_trials),
+            },
+        )
+
         try:
-            request = NextTrialRequest(
-                session_id=self.session_id,
-                previous_results=previous_results or self._completed_trials[-5:],
-                request_metadata={
-                    "dataset_size": dataset_size,
-                    "completed_trials": len(self._completed_trials),
-                },
-            )
-
             response = await self.remote_service.get_next_trial(request)
-
-            # Update local session status
-            if self.session:
-                self.session.status = response.session_status
-
-            if not response.should_continue or not response.suggestion:
-                self._completion_reason = (
-                    response.reason or "cloud brain completed optimization"
-                )
-                logger.info(f"Optimization complete: {self._completion_reason}")
-                return None
-
-            self._completion_reason = None
-            suggestion = response.suggestion
-
-            # Store pending trial
-            self._pending_trials[suggestion.trial_id] = suggestion
-
-            logger.info(
-                f"Got suggestion {suggestion.trial_id}: "
-                f"{suggestion.exploration_type} with "
-                f"{len(suggestion.dataset_subset.indices)} examples"
-            )
-
-            return suggestion
-
         except Exception as e:
             logger.error(f"Failed to get next suggestion: {e}")
             raise OptimizationError(f"Failed to get suggestion: {e}") from e
+
+        # Update local session status
+        if self.session:
+            self.session.status = response.session_status
+
+        if not response.should_continue:
+            self._completion_reason = (
+                response.stop_reason
+                or response.reason
+                or "cloud brain completed optimization"
+            )
+            logger.info(f"Optimization complete: {self._completion_reason}")
+            return None
+
+        if not response.suggestion:
+            raise OptimizationError(
+                "Cloud brain returned no suggestion while should_continue=True"
+            )
+
+        self._completion_reason = None
+        suggestion = response.suggestion
+
+        # Store pending trial
+        self._pending_trials[suggestion.trial_id] = suggestion
+
+        logger.info(
+            f"Got suggestion {suggestion.trial_id}: "
+            f"{suggestion.exploration_type} with "
+            f"{len(suggestion.dataset_subset.indices)} examples"
+        )
+
+        return suggestion
 
     async def suggest_next_trial_async(
         self,

--- a/traigent/optimizers/interactive_optimizer.py
+++ b/traigent/optimizers/interactive_optimizer.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import time
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any, Protocol, TypeAlias
+from typing import TYPE_CHECKING, Any, Protocol, TypeAlias, cast
 
 from traigent.api.types import TrialResult
 from traigent.api.types import TrialStatus as SDKTrialStatus
@@ -94,7 +94,7 @@ def _coerce_trial_status(status: TrialStatusLike) -> Any:
 
 def _is_completed_status(status: TrialStatusLike) -> bool:
     """Check completion across SDK and cloud status enums."""
-    return getattr(status, "value", status) == "completed"
+    return bool(getattr(status, "value", status) == "completed")
 
 
 def _string_sequence(value: Any) -> tuple[str, ...]:
@@ -102,6 +102,23 @@ def _string_sequence(value: Any) -> tuple[str, ...]:
     if not isinstance(value, (list, tuple, set)):
         return ()
     return tuple(str(item) for item in value if item)
+
+
+class CloudBrainOptimizationComplete(RuntimeError):
+    """Normal cloud-brain terminal signal from the next-trial API."""
+
+    def __init__(self, reason: str | None = None) -> None:
+        self.reason = reason or "cloud brain completed optimization"
+        super().__init__(self.reason)
+
+    @property
+    def stop_reason(self) -> str:
+        normalized = self.reason.lower().replace("-", "_").replace(" ", "_")
+        if "max" in normalized and "trial" in normalized:
+            return "max_trials_reached"
+        if "conver" in normalized:
+            return "convergence"
+        return "optimizer"
 
 
 class RemoteGuidanceService(Protocol):
@@ -185,6 +202,7 @@ class InteractiveOptimizer(BaseOptimizer):
         self._pending_trials: dict[str, TrialSuggestion] = {}
         self._completed_trials: list[TrialResultSubmission] = []
         self._start_time: float | None = None
+        self._completion_reason: str | None = None
 
     async def initialize_session(
         self,
@@ -288,9 +306,13 @@ class InteractiveOptimizer(BaseOptimizer):
                 self.session.status = response.session_status
 
             if not response.should_continue or not response.suggestion:
-                logger.info(f"Optimization complete: {response.reason}")
+                self._completion_reason = (
+                    response.reason or "cloud brain completed optimization"
+                )
+                logger.info(f"Optimization complete: {self._completion_reason}")
                 return None
 
+            self._completion_reason = None
             suggestion = response.suggestion
 
             # Store pending trial
@@ -323,7 +345,7 @@ class InteractiveOptimizer(BaseOptimizer):
             dataset_size=max(dataset_size, 1),
         )
         if suggestion is None:
-            raise OptimizationError("Cloud brain returned no further suggestions")
+            raise CloudBrainOptimizationComplete(self._completion_reason)
 
         config = dict(suggestion.config or {})
         config["_traigent_backend_trial_id"] = suggestion.trial_id
@@ -509,8 +531,8 @@ class InteractiveOptimizer(BaseOptimizer):
         # Simple comparison on primary objective
         if self.objectives and self.objectives[0] in metrics:
             primary = self.objectives[0]
-            current = metrics.get(primary, 0)
-            best = self.session.best_metrics.get(primary, 0)
+            current = float(metrics.get(primary, 0.0))
+            best = float(self.session.best_metrics.get(primary, 0.0))
 
             # Assume higher is better for now
             return current > best
@@ -568,7 +590,10 @@ class InteractiveOptimizer(BaseOptimizer):
                 ),
                 effectuation_events=result_metadata.get("effectuation_events"),
             )
-            return merge_tvar_observation_metadata(result_metadata, observation)
+            return cast(
+                dict[str, Any],
+                merge_tvar_observation_metadata(result_metadata, observation),
+            )
         except Exception as exc:
             logger.debug(
                 "Skipping TVAR observation metadata for trial %s: %s",


### PR DESCRIPTION
## Summary

Completes the smart-pruning fixes uncovered by live SDK↔backend e2e against real api-dev (follow-up to the #1589 wiring + the dev8 D1 attempt). **Client-confirmed RESOLVED on dev10** (cloud session `c84c53fb`, exp `325adb9a`, pruned-count=6 retained, no local fallback, optimum kept).

### D1 — correctness (the dangerous bug)
The dev8 attempt fixed the wrong path (exact-match accuracy on the non-detailed callback). The cloud smart-pruning run uses the **detailed** path (`_build_progress_payload`) and scores via **`metric_functions`** (LocalEvaluator), so `running_score` streamed degenerate `0.0` and the backend's `optimistic_ceiling_below_best` **pruned the global optimum**.
- `_build_progress_payload` now streams the **configured objective** the same way final scoring does — polymorphic over `LocalEvaluator._invoke_metric_function` / `SimpleScoringEvaluator._call_metric_functions`, exact-match only as fallback when neither is configured. Raw scorer scale preserved; report payload stays content-free.
- Live result: `running_score` tracks true accuracy; optimum `level=9` kept (94.26), only genuine losers pruned.

### D3 — durability / fail-open
A prune-heavy run still failed open: the backend's submission-time slot acquisition returns `should_continue=False` on graceful completion, which was dropped to `None`, misread as backend degradation → `mark_local_fallback` → the run silently re-ran as **local random search** (`experiment_id=null`, pruned-count=0, last pruned trial dropped).
- `trial_operations.request_trial_slot()` now returns a typed `TrialSlotResult` distinguishing **graceful completion** (HTTP 200 + `should_continue=False` + no id) from genuine no-slot/error. Only graceful completion finalizes the **cloud** result; **every real failure still `mark_local_fallback` exactly as before** (fail-closed preserved).
- Propagated through `backend_client` → `backend_session_manager`; `_handle_trial_result` raises the existing `CloudBrainOptimizationComplete` after bookkeeping → orchestrator finalizes → cloud `OptimizationResult` with `experiment_id`/`cloud_url` and retained pruned trials.
- Parallel batches **drain** before the terminal break (no sibling-result loss); pruned/failed results reuse the already-minted backend id (fixes the dropped pruned trial).
- Also includes: `CloudBrainOptimizationComplete` for the InteractiveOptimizer completion path + `should_continue=True`-without-suggestion still raises.

## PR checklist
1. **Worst-case prod path:** fail-OPEN being CLOSED. A graceful `should_continue=False` completion finalizes the cloud result; a genuine connectivity/HTTP/transport failure (or malformed `should_continue=True`) STILL degrades to local fallback exactly as before. Verified by codex governance review (no real failure hidden as completion) + a `test_*` asserting connectivity-class failure still marks `local_fallback`.
2. **Production-branch test:** `tests/unit/cloud/test_trial_operations.py` (completion vs unavailable, incl. HTTP 500 / transport / `should_continue=True`-no-id); `tests/unit/core/test_backend_session_manager.py` (completion does not degrade; connectivity still degrades); `tests/unit/core/test_orchestrator.py` (terminal completion finalizes a CLOUD result with experiment metadata + retained pruned trial; parallel batch drains).
3. **Contract regeneration:** none — no schema/DTO shape change (uses existing `intermediate_report` + `/next-trial` contracts).
4. **Public surface delta:** none (internal evaluator/orchestrator/cloud-transport; inert unless `smart_pruning` is enabled on a managed/cloud run).
5. **Review threads:** will resolve all before merge.
6. **Quality gates:** not relaxed. Full SDK unit suite **13,923 passed** (captain re-run, isolated venv); ruff + mypy clean on changed files.

## Verification
- Full unit suite 13,923 passed / 39 skipped (captain).
- codex diagnosis review (confirmed the LocalEvaluator path, prevented a third miss) + codex fix-review GO + codex governance review of the fail-open (fail-closed preserved) + parallel-drain blocker fixed.
- **Live e2e GREEN on dev10** (client): durable cloud result, optimum kept, prunes retained, no local fallback, D1/D2 hold, double-callback clean, prune_reason surfaced, genuine-fallback intact.

Spine: cs_4ea49f57dc2b65c9
Spine-Trail: st_265db9b2a247